### PR TITLE
fix(keys): flatten nested opts tables to match LazyKeysSpec

### DIFF
--- a/lua/denops-plugins/denops-vim/keys.lua
+++ b/lua/denops-plugins/denops-vim/keys.lua
@@ -8,7 +8,7 @@ local keys = {
     end,
     mode = "n",
     desc = "",
-    { silent = true },
+    silent = true,
   },
   ---- Interrupt the process of plugins via <C-c>
   --vim.keymap.set({ "n", "v", "x", "s", "o" }, "<C-c>", "<Cmd>call denops#interrupt()<CR><C-c>", { silent = true })

--- a/lua/plugins/calcium-nvim/keys.lua
+++ b/lua/plugins/calcium-nvim/keys.lua
@@ -7,12 +7,10 @@ local keys = {
       "n",
       "v",
     },
-    {
-      desc = "Calculate",
-      --expr = true,
-      --noremap = true,
-      silent = true,
-    },
+    desc = "Calculate",
+    --expr = true,
+    --noremap = true,
+    silent = true,
   },
 }
 

--- a/lua/plugins/convy-nvim/keys.lua
+++ b/lua/plugins/convy-nvim/keys.lua
@@ -7,10 +7,8 @@ local keys = {
       "n",
       "v",
     },
-    {
-      desc = "Convert (interactive selection)",
-      silent = true,
-    },
+    desc = "Convert (interactive selection)",
+    silent = true,
   },
   {
     "<leader>cd",
@@ -19,10 +17,8 @@ local keys = {
       "n",
       "v",
     },
-    {
-      desc = "Convert to decimal",
-      silent = true,
-    },
+    desc = "Convert to decimal",
+    silent = true,
   },
   {
     "<leader>cs",
@@ -30,10 +26,8 @@ local keys = {
     mode = {
       "v",
     },
-    {
-      desc = "Set conversion separator (visual selection)",
-      silent = true,
-    },
+    desc = "Set conversion separator (visual selection)",
+    silent = true,
   },
 }
 

--- a/lua/plugins/lazyissues/keys.lua
+++ b/lua/plugins/lazyissues/keys.lua
@@ -9,12 +9,10 @@ local keys = {
     mode = {
       "n",
     },
-    {
-      desc = "Issues",
-      --expr = true,
-      --noremap = true,
-      silent = true,
-    },
+    desc = "Issues",
+    --expr = true,
+    --noremap = true,
+    silent = true,
   },
 }
 

--- a/lua/plugins/peeper-picker-nvim/keys.lua
+++ b/lua/plugins/peeper-picker-nvim/keys.lua
@@ -8,12 +8,10 @@ local keys = {
     mode = {
       "n",
     },
-    {
-      desc = "Peeper Picker",
-      --expr = true,
-      --noremap = true,
-      silent = true,
-    },
+    desc = "Peeper Picker",
+    --expr = true,
+    --noremap = true,
+    silent = true,
   },
   {
     "<leader>ph",
@@ -23,12 +21,10 @@ local keys = {
     mode = {
       "n",
     },
-    {
-      desc = "Peeper Picker History",
-      --expr = true,
-      --noremap = true,
-      silent = true,
-    },
+    desc = "Peeper Picker History",
+    --expr = true,
+    --noremap = true,
+    silent = true,
   },
 }
 

--- a/lua/plugins/select-undo-nvim/keys.lua
+++ b/lua/plugins/select-undo-nvim/keys.lua
@@ -8,11 +8,9 @@ local keys = {
     mode = {
       "x",
     },
-    {
-      desc = "Selective undo: newest change in selection",
-      noremap = true,
-      silent = true,
-    },
+    desc = "Selective undo: newest change in selection",
+    noremap = true,
+    silent = true,
   },
   {
     "gU",
@@ -22,11 +20,9 @@ local keys = {
     mode = {
       "x",
     },
-    {
-      desc = "Selective undo: last change of every selected line",
-      noremap = true,
-      silent = true,
-    },
+    desc = "Selective undo: last change of every selected line",
+    noremap = true,
+    silent = true,
   },
   {
     "gC",
@@ -36,11 +32,9 @@ local keys = {
     mode = {
       "x",
     },
-    {
-      desc = "Selective undo for character selection",
-      noremap = true,
-      silent = true,
-    },
+    desc = "Selective undo for character selection",
+    noremap = true,
+    silent = true,
   },
 }
 

--- a/lua/plugins/tabterm-nvim/keys.lua
+++ b/lua/plugins/tabterm-nvim/keys.lua
@@ -8,10 +8,8 @@ local keys = {
     mode = {
       "n",
     },
-    {
-      desc = "Toggle tabterm",
-      silent = true,
-    },
+    desc = "Toggle tabterm",
+    silent = true,
   },
   {
     "<leader>ts",
@@ -21,10 +19,8 @@ local keys = {
     mode = {
       "n",
     },
-    {
-      desc = "New tabterm shell",
-      silent = true,
-    },
+    desc = "New tabterm shell",
+    silent = true,
   },
   {
     "<leader>tc",
@@ -34,10 +30,8 @@ local keys = {
     mode = {
       "n",
     },
-    {
-      desc = "New tabterm command",
-      silent = true,
-    },
+    desc = "New tabterm command",
+    silent = true,
   },
 }
 

--- a/lua/plugins/tobira-nvim/keys.lua
+++ b/lua/plugins/tobira-nvim/keys.lua
@@ -12,13 +12,11 @@ local keys = {
       --"x",
       --"v",
     },
-    {
-      desc = "",
-      -- TODO: it
-      --expr = true,
-      --noremap = true,
-      silent = true,
-    },
+    desc = "",
+    -- TODO: it
+    --expr = true,
+    --noremap = true,
+    silent = true,
   },
 }
 


### PR DESCRIPTION
The desc/silent/noremap options were nested inside an extra positional table literal in each keymap entry. lazy.nvim's LazyKeysSpec expects these as named fields at the top level of the keymap table, so the nested form was silently ignored (no which-key descriptions, no silent).

Move the options to the top level across the 8 affected keys.lua files. Verified with neowright: maparg now reports the correct desc and silent=1 for the fixed mappings.