### PR TITLE
feat(scripts): add nvim-worktree.sh for NVIM_APPNAME-isolated worktrees

### DIFF
--- a/.claude/skills/nvim-worktree/SKILL.md
+++ b/.claude/skills/nvim-worktree/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: nvim-worktree
+description: >
+  Create, list, and remove parallel Neovim-config git worktrees isolated by
+  NVIM_APPNAME, using scripts/nvim-worktree.sh. Each worktree lives at
+  ~/.config/nvim-<name> (a sibling of the main config) and gets its own
+  plugin/data dirs (lazy + treesitter copied, mason symlink-shared) plus a
+  direnv .envrc so `cd`-ing in auto-activates NVIM_APPNAME. Use when the user
+  wants to work on another branch of this config in parallel without switching
+  branches, e.g. "/nvim-worktree add add/prompt-nvim".
+argument-hint: "add <branch> [name] | remove <name> [--force] | list"
+---
+
+# Manage NVIM_APPNAME-isolated worktrees
+
+Thin wrapper around `scripts/nvim-worktree.sh`. Run the script; it does the
+git, data-seeding, and direnv wiring. Do not re-implement its steps by hand.
+
+## Why this exists
+
+Neovim reads `~/.config/nvim` by default, so a worktree checked out elsewhere is
+**not** picked up automatically. `NVIM_APPNAME=nvim-<name>` makes Neovim read
+`~/.config/nvim-<name>` instead — and because this config is fully
+`vim.fn.stdpath()`-based (`lua/config/lazy.lua`), plugins/data/state isolate
+cleanly too. Placing the worktree at `~/.config/nvim-<name>` satisfies both the
+git-worktree sibling-directory convention and Neovim's `~/.config/nvim-*`
+convention at once.
+
+## Commands
+
+Parse `$ARGUMENTS` for the subcommand and pass it straight through.
+
+- **add `<branch> [name]`** — create a worktree for `<branch>` at
+  `~/.config/nvim-<name>`. If `name` is omitted it is derived from the branch
+  (`add/prompt-nvim` → `prompt`). The script also:
+  - seeds `~/.local/share/nvim-<name>` by copying `lazy/` + `site/` and
+    symlinking `mason/` from the main data dir (so first launch does **not**
+    re-download every plugin / LSP server / parser);
+  - writes `.envrc` (`export NVIM_APPNAME=nvim-<name>`), adds `.envrc` to
+    `.git/info/exclude`, and runs `direnv allow`.
+
+  ```bash
+  scripts/nvim-worktree.sh add add/prompt-nvim
+  ```
+
+- **remove `<name> [--force]`** — `git worktree remove` the worktree and delete
+  its `~/.local/{share,state,cache}/nvim-<name>` dirs. Accepts `prompt` or
+  `nvim-prompt`. **Never deletes the git branch** (merging to master is a manual
+  decision); tell the user to `git branch -d <branch>` themselves if they want.
+
+  ```bash
+  scripts/nvim-worktree.sh remove prompt
+  ```
+
+- **list** — show `git worktree list`.
+
+  ```bash
+  scripts/nvim-worktree.sh list
+  ```
+
+## After adding
+
+Report to the user how to launch it:
+
+- with direnv active: `cd ~/.config/nvim-<name>` then just `nvim`;
+- otherwise: `NVIM_APPNAME=nvim-<name> nvim`.
+
+## Caveats to surface when relevant
+
+- `mason/` is symlink-shared, so `:Mason` **uninstall** inside a worktree
+  affects the shared store (install/update is fine — shared cache).
+- To vendor a plugin from inside a worktree via `/add-plugin`, set
+  `NVIM_PLUGINS_DIR=~/.config/nvim-<name>/lua/plugins` (the clone script
+  otherwise hardcodes the main config path).
+- `lazy-lock.json` is gitignored, so a fresh worktree has none; plugins resolve
+  to latest. Copy the main lockfile and `:Lazy restore` only if version parity
+  matters.

--- a/.claude/skills/nvim-worktree/SKILL.md
+++ b/.claude/skills/nvim-worktree/SKILL.md
@@ -4,7 +4,8 @@ description: >
   Create, list, and remove parallel Neovim-config git worktrees isolated by
   NVIM_APPNAME, using scripts/nvim-worktree.sh. Each worktree lives at
   ~/.config/nvim-<name> (a sibling of the main config) and gets its own
-  plugin/data dirs (lazy + treesitter copied, mason symlink-shared) plus a
+  plugin/data dirs (lazy + treesitter copied, all other data dirs like mason /
+  lazy-rocks / databases symlink-shared, whole cache dir symlink-shared) plus a
   direnv .envrc so `cd`-ing in auto-activates NVIM_APPNAME. Use when the user
   wants to work on another branch of this config in parallel without switching
   branches, e.g. "/nvim-worktree add add/prompt-nvim".
@@ -33,9 +34,11 @@ Parse `$ARGUMENTS` for the subcommand and pass it straight through.
 - **add `<branch> [name]`** — create a worktree for `<branch>` at
   `~/.config/nvim-<name>`. If `name` is omitted it is derived from the branch
   (`add/prompt-nvim` → `prompt`). The script also:
-  - seeds `~/.local/share/nvim-<name>` by copying `lazy/` + `site/` and
-    symlinking `mason/` from the main data dir (so first launch does **not**
-    re-download every plugin / LSP server / parser);
+  - seeds `~/.local/share/nvim-<name>` by copying `lazy/` + `site/` (per-branch)
+    and symlinking **every other data dir** back to the main data dir (`mason/`,
+    `lazy-rocks/`, `databases/`, `kulala.nvim/`, …), plus symlinks the whole
+    `~/.cache/nvim-<name>` → `~/.cache/nvim` — so first launch does **not**
+    re-download plugins / LSP servers / rocks or recompile parsers;
   - writes `.envrc` (`export NVIM_APPNAME=nvim-<name>`), adds `.envrc` to
     `.git/info/exclude`, and runs `direnv allow`.
 
@@ -67,8 +70,10 @@ Report to the user how to launch it:
 
 ## Caveats to surface when relevant
 
-- `mason/` is symlink-shared, so `:Mason` **uninstall** inside a worktree
-  affects the shared store (install/update is fine — shared cache).
+- Every data dir except `lazy/` + `site/` is symlink-shared (mason, lazy-rocks,
+  databases, …), and the whole cache dir is too. So a **delete/uninstall** inside
+  a worktree (e.g. `:Mason` uninstall) affects the shared store; install/update
+  is fine — it just populates the shared cache for everyone.
 - To vendor a plugin from inside a worktree via `/add-plugin`, set
   `NVIM_PLUGINS_DIR=~/.config/nvim-<name>/lua/plugins` (the clone script
   otherwise hardcodes the main config path).

--- a/scripts/nvim-worktree.sh
+++ b/scripts/nvim-worktree.sh
@@ -13,11 +13,16 @@ set -euo pipefail
 # .envrc + direnv are active) loads the worktree as a fully isolated config.
 #
 # Data isolation (avoids re-downloading everything on first launch, since
-# NVIM_APPNAME also redirects stdpath("data")):
-#   - lazy/ (plugins) and site/ (treesitter parsers) are real copies
-#   - mason/ (large LSP/tool binaries) is a symlink back to the main data dir
-#     so it is shared, not duplicated. Uninstalling via :Mason inside a
-#     worktree therefore affects the shared store.
+# NVIM_APPNAME also redirects stdpath("data") and stdpath("cache")):
+#   - lazy/ (plugins) and site/ (treesitter parsers) are real copies, so each
+#     worktree can diverge per-branch (plugin specs / parser sets).
+#   - every OTHER entry in the main data dir (mason/, lazy-rocks/, databases/,
+#     kulala.nvim/, cord/, loose files, ...) is symlink-shared back to the main
+#     data dir, so heavy downloads/builds are not re-fetched. Writes/deletes in
+#     any shared dir (e.g. :Mason uninstall, luarocks) affect the shared store.
+#   - the entire cache dir is a single symlink back to the main cache dir
+#     (cache is regenerable and shared-safe: luac bytecode, treesitter parsers,
+#     colorscheme cache, ...).
 #
 # Runnable from anywhere: it resolves the main config repo as the parent of
 # this script's directory, so all git commands target the right repository.
@@ -47,9 +52,9 @@ readonly STATE_HOME="${XDG_STATE_HOME:-${HOME}/.local/state}"
 readonly CACHE_HOME="${XDG_CACHE_HOME:-${HOME}/.cache}"
 readonly MAIN_APP="nvim"
 
-# Real-copy these subdirs of the main data dir; symlink-share these.
+# Real-copy these subdirs of the main data dir (per-branch isolation); every
+# other entry in the main data dir is symlink-shared instead.
 readonly COPY_DIRS=(lazy site)
-readonly LINK_DIRS=(mason)
 
 die() {
     printf 'error: %s\n' "$*" >&2
@@ -69,8 +74,19 @@ derive_name() {
     printf '%s' "${n}"
 }
 
-# Seed a fresh per-app data dir so lazy/mason/treesitter are reused, not
-# re-fetched. Existing entries are left untouched (idempotent).
+# True if $1 is one of the real-copy dirs.
+is_copy_dir() {
+    local x
+    for x in "${COPY_DIRS[@]}"; do
+        [ "${x}" = "$1" ] && return 0
+    done
+    return 1
+}
+
+# Seed a fresh per-app data dir so plugins/binaries/caches are reused, not
+# re-fetched. COPY_DIRS are real-copied (per-branch); every other entry in the
+# main data dir is symlink-shared. Existing entries are left untouched
+# (idempotent).
 seed_data() {
     local appname="$1"
     local src="${DATA_HOME}/${MAIN_APP}"
@@ -82,19 +98,41 @@ seed_data() {
     }
     mkdir -p "${dst}"
 
-    local d
-    for d in "${COPY_DIRS[@]}"; do
-        if [ -d "${src}/${d}" ] && [ ! -e "${dst}/${d}" ]; then
-            printf '  copy   %s\n' "${d}"
-            cp -r "${src}/${d}" "${dst}/${d}"
+    # `shopt -p` exits non-zero when the option is unset; guard against set -e.
+    local prev_dotglob prev_nullglob
+    prev_dotglob="$(shopt -p dotglob || true)"
+    prev_nullglob="$(shopt -p nullglob || true)"
+    shopt -s dotglob nullglob
+
+    local path base
+    for path in "${src}"/*; do
+        base="$(basename "${path}")"
+        [ -e "${dst}/${base}" ] && continue
+        if is_copy_dir "${base}" && [ -d "${path}" ]; then
+            printf '  copy   %s\n' "${base}"
+            cp -r "${path}" "${dst}/${base}"
+        else
+            printf '  link   %s -> %s\n' "${base}" "${path}"
+            ln -s "${path}" "${dst}/${base}"
         fi
     done
-    for d in "${LINK_DIRS[@]}"; do
-        if [ -e "${src}/${d}" ] && [ ! -e "${dst}/${d}" ]; then
-            printf '  link   %s -> %s\n' "${d}" "${src}/${d}"
-            ln -s "${src}/${d}" "${dst}/${d}"
-        fi
-    done
+
+    eval "${prev_dotglob}"
+    eval "${prev_nullglob}"
+}
+
+# Seed the per-app cache dir as a single symlink back to the main cache dir.
+# Cache is regenerable and shared-safe. Idempotent.
+seed_cache() {
+    local appname="$1"
+    local src="${CACHE_HOME}/${MAIN_APP}"
+    local dst="${CACHE_HOME}/${appname}"
+
+    [ -d "${src}" ] || return 0
+    [ -e "${dst}" ] && return 0
+
+    ln -s "${src}" "${dst}"
+    printf '  link   cache -> %s\n' "${src}"
 }
 
 # Write .envrc for direnv auto-activation and keep it out of git.
@@ -134,6 +172,7 @@ cmd_add() {
     printf 'creating worktree %s -> %s\n' "${appname}" "${branch}"
     git -C "${REPO_ROOT}" worktree add "${wt}" "${branch}"
     seed_data "${appname}"
+    seed_cache "${appname}"
     write_envrc "${wt}" "${appname}"
     printf 'done. launch: NVIM_APPNAME=%s nvim   (or cd %s)\n' "${appname}" "${wt}"
 }

--- a/scripts/nvim-worktree.sh
+++ b/scripts/nvim-worktree.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# nvim-worktree.sh - Manage parallel Neovim-config git worktrees isolated by
+# NVIM_APPNAME.
+#
+# Each worktree lives at ~/.config/nvim-<name>, a sibling of the main config.
+# That single location satisfies two independent best practices at once:
+#   - git worktree: keep linked worktrees as siblings of the main clone
+#     (never nested inside it, which breaks .git resolution)
+#   - Neovim NVIM_APPNAME: alternate configs live at ~/.config/nvim-*
+# so `NVIM_APPNAME=nvim-<name> nvim` (or just `cd`-ing in when the generated
+# .envrc + direnv are active) loads the worktree as a fully isolated config.
+#
+# Data isolation (avoids re-downloading everything on first launch, since
+# NVIM_APPNAME also redirects stdpath("data")):
+#   - lazy/ (plugins) and site/ (treesitter parsers) are real copies
+#   - mason/ (large LSP/tool binaries) is a symlink back to the main data dir
+#     so it is shared, not duplicated. Uninstalling via :Mason inside a
+#     worktree therefore affects the shared store.
+#
+# Runnable from anywhere: it resolves the main config repo as the parent of
+# this script's directory, so all git commands target the right repository.
+#
+# Usage:
+#   scripts/nvim-worktree.sh add <branch> [name]
+#   scripts/nvim-worktree.sh remove <name> [--force]
+#   scripts/nvim-worktree.sh list
+#
+# Examples:
+#   scripts/nvim-worktree.sh add add/prompt-nvim       # -> ~/.config/nvim-prompt
+#   scripts/nvim-worktree.sh add feature/x myconfig    # -> ~/.config/nvim-myconfig
+#   scripts/nvim-worktree.sh remove prompt             # remove worktree + data
+#   scripts/nvim-worktree.sh list
+#
+# Note: `remove` deletes the worktree and its per-app data/state/cache dirs but
+# NEVER deletes the git branch (merging to master stays a manual decision).
+#
+# XDG overrides are honoured (XDG_CONFIG_HOME / XDG_DATA_HOME / ...).
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_ROOT="$(dirname "${SCRIPT_DIR}")"
+
+readonly CONFIG_HOME="${XDG_CONFIG_HOME:-${HOME}/.config}"
+readonly DATA_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}"
+readonly STATE_HOME="${XDG_STATE_HOME:-${HOME}/.local/state}"
+readonly CACHE_HOME="${XDG_CACHE_HOME:-${HOME}/.cache}"
+readonly MAIN_APP="nvim"
+
+# Real-copy these subdirs of the main data dir; symlink-share these.
+readonly COPY_DIRS=(lazy site)
+readonly LINK_DIRS=(mason)
+
+die() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+usage() {
+    sed -n '5,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit "${1:-0}"
+}
+
+# Derive a short app name from a branch: add/prompt-nvim -> prompt
+derive_name() {
+    local n="${1##*/}"   # after last slash
+    n="${n%-nvim}"       # strip trailing -nvim
+    n="${n%.nvim}"       # strip trailing .nvim
+    printf '%s' "${n}"
+}
+
+# Seed a fresh per-app data dir so lazy/mason/treesitter are reused, not
+# re-fetched. Existing entries are left untouched (idempotent).
+seed_data() {
+    local appname="$1"
+    local src="${DATA_HOME}/${MAIN_APP}"
+    local dst="${DATA_HOME}/${appname}"
+
+    [ -d "${src}" ] || {
+        printf 'note: main data dir %s not found; skipping seed\n' "${src}"
+        return 0
+    }
+    mkdir -p "${dst}"
+
+    local d
+    for d in "${COPY_DIRS[@]}"; do
+        if [ -d "${src}/${d}" ] && [ ! -e "${dst}/${d}" ]; then
+            printf '  copy   %s\n' "${d}"
+            cp -r "${src}/${d}" "${dst}/${d}"
+        fi
+    done
+    for d in "${LINK_DIRS[@]}"; do
+        if [ -e "${src}/${d}" ] && [ ! -e "${dst}/${d}" ]; then
+            printf '  link   %s -> %s\n' "${d}" "${src}/${d}"
+            ln -s "${src}/${d}" "${dst}/${d}"
+        fi
+    done
+}
+
+# Write .envrc for direnv auto-activation and keep it out of git.
+write_envrc() {
+    local wt="$1" appname="$2"
+    local envrc="${wt}/.envrc"
+
+    if [ ! -e "${envrc}" ]; then
+        printf 'export NVIM_APPNAME=%s\n' "${appname}" > "${envrc}"
+        printf '  write  .envrc (NVIM_APPNAME=%s)\n' "${appname}"
+    fi
+
+    # Exclude .envrc from git without committing. info/exclude lives in the
+    # common git dir, so this covers every worktree at once.
+    local exclude
+    exclude="$(git -C "${REPO_ROOT}" rev-parse --git-common-dir)/info/exclude"
+    if [ -f "${exclude}" ] && ! grep -qxF '.envrc' "${exclude}"; then
+        printf '.envrc\n' >> "${exclude}"
+    fi
+
+    if command -v direnv >/dev/null 2>&1; then
+        ( cd "${wt}" && direnv allow . ) && printf '  direnv allow\n'
+    else
+        printf '  note: direnv not found; run `NVIM_APPNAME=%s nvim` manually\n' "${appname}"
+    fi
+}
+
+cmd_add() {
+    local branch="${1:-}"
+    [ -n "${branch}" ] || die "add: <branch> required"
+    local name="${2:-$(derive_name "${branch}")}"
+    local appname="nvim-${name}"
+    local wt="${CONFIG_HOME}/${appname}"
+
+    [ -e "${wt}" ] && die "already exists: ${wt}"
+
+    printf 'creating worktree %s -> %s\n' "${appname}" "${branch}"
+    git -C "${REPO_ROOT}" worktree add "${wt}" "${branch}"
+    seed_data "${appname}"
+    write_envrc "${wt}" "${appname}"
+    printf 'done. launch: NVIM_APPNAME=%s nvim   (or cd %s)\n' "${appname}" "${wt}"
+}
+
+cmd_remove() {
+    local name="${1:-}"
+    [ -n "${name}" ] || die "remove: <name> required"
+    shift || true
+    name="${name#nvim-}"   # accept either 'prompt' or 'nvim-prompt'
+    local appname="nvim-${name}"
+    local wt="${CONFIG_HOME}/${appname}"
+
+    printf 'removing worktree %s\n' "${wt}"
+    git -C "${REPO_ROOT}" worktree remove "${wt}" "$@"
+
+    local dir
+    for dir in "${DATA_HOME}/${appname}" "${STATE_HOME}/${appname}" "${CACHE_HOME}/${appname}"; do
+        if [ -e "${dir}" ]; then
+            printf '  rm     %s\n' "${dir}"
+            rm -rf "${dir}"
+        fi
+    done
+    printf 'done. git branch left intact (delete manually if desired: git branch -d <branch>)\n'
+}
+
+cmd_list() {
+    git -C "${REPO_ROOT}" worktree list
+}
+
+main() {
+    local sub="${1:-}"
+    shift || true
+    case "${sub}" in
+        add)    cmd_add "$@" ;;
+        remove) cmd_remove "$@" ;;
+        list)   cmd_list "$@" ;;
+        -h | --help | help | "") usage 0 ;;
+        *) die "unknown subcommand: ${sub} (try: add | remove | list)" ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
Manage parallel Neovim-config git worktrees at ~/.config/nvim-<name>,
isolated via NVIM_APPNAME. Subcommands: add/remove/list.

add seeds the per-app data dir (copies lazy/ and site/, symlinks mason/)
so a fresh worktree does not re-download every plugin, LSP server, and
treesitter parser, then writes an .envrc and runs direnv allow. remove
deletes the worktree and its data/state/cache dirs but never the git
branch.