### PR TITLE
fix(conform): stop typos formatter from auto-fixing edn->end

### DIFF
--- a/lua/plugins/conform-nvim/opts.lua
+++ b/lua/plugins/conform-nvim/opts.lua
@@ -68,7 +68,12 @@ local opts = {
     tex = { "tex-fmt" },
 
     -- Use the "*" filetype to run formatters on all filetypes.
-    ["*"] = { "typos" },
+    -- Disabled: as a conform formatter, typos runs with `--write-changes` and
+    -- auto-"fixes" default-dictionary false positives (e.g. Clojure `edn` ->
+    -- `end`), corrupting files on save. Typo checking is a linter's job, not a
+    -- formatter's; it will move to nvim-lint (planned), which only reports
+    -- diagnostics without rewriting the buffer. Kept here for reference.
+    -- ["*"] = { "typos" },
 
     -- Use the "_" filetype to run formatters on filetypes that don't have other formatters configured.
     ["_"] = { "trim_whitespace" },


### PR DESCRIPTION
Running typos as a conform formatter uses `--write-changes`, so its default-dictionary false positives get auto-applied on save. Clojure EDN (`.edn`) breaks because typos "corrects" `edn` to `end`.

Detection-without-mutation is a linter's job, not a formatter's. Comment out the `["*"] = { "typos" }` wiring (kept for reference); typo checking will move to nvim-lint.