### PR TITLE
fix(nvim-notify): take over vim.notify so opts.level actually applies

### DIFF
--- a/lua/plugins/nvim-notify/init.lua
+++ b/lua/plugins/nvim-notify/init.lua
@@ -13,6 +13,12 @@ local spec = {
     local opts = require("plugins.nvim-notify.opts")
     require("notify").setup(opts)
 
+    -- setup() alone changes nothing: the built-in vim.notify never consults
+    -- notify's config, so opts.level is ignored and DEBUG-level messages from
+    -- plugins still get echoed to the message area. Taking over vim.notify is
+    -- what actually applies the level gate.
+    vim.notify = require("notify")
+
     require("telescope").load_extension("notify")
   end,
   --cond = false,


### PR DESCRIPTION
setup() only stores notify's config; it does not install notify as the notification handler. The built-in vim.notify never consults that config, so opts.level was inert and DEBUG-level messages kept being echoed to the message area -- most visibly tobira.nvim's per-keymap "X is remapped (...) -- removed from suggestion pool" lines, 8 of them on every startup since tobira upstream added the check.

Assigning vim.notify in config() is enough for that case: tobira lists nvim-notify in its dependencies, so lazy.nvim loads and configures notify before tobira's setup() runs. Verified with neowright: :messages goes from 8 tobira lines to completely empty, while INFO and ERROR notifications still render and DEBUG is dropped.