### PR TITLE
fix(filetype): prioritize dotenv pattern over builtin env

### DIFF
--- a/filetype.lua
+++ b/filetype.lua
@@ -3,14 +3,22 @@ vim.filetype.add({
   extension = {
     env = "dotenv",
   },
+
   -- Mappings based on FULL filename
   filename = {
     [".env"] = "dotenv",
     ["env"] = "dotenv",
   },
+
   -- Mappings based on filename pattern match
   pattern = {
-    -- Match filenames like ".env.development", "env.local" and so on
-    [".?env.*"] = "dotenv",
+    -- Match filenames like ".env.development", "env.local" and so on.
+    -- The priority is needed to beat Neovim's built-in `.env.*` -> `env` pattern.
+    ["%.?env%..*"] = {
+      "dotenv",
+      {
+        priority = 10,
+      },
+    },
   },
 })


### PR DESCRIPTION
Neovim's built-in `.env.*` -> `env` pattern was winning over the custom mapping, so `.env.development` opened as `env` instead of `dotenv`. Set an explicit priority and escape the dots in the Lua pattern, which was loose enough to match unrelated names like `seven.txt`.