### PR TITLE
docs(steering): sync structure with config module split

### DIFF
--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -1,5 +1,8 @@
 # Product Vision
 
+<!-- updated_at: 2026-07-31 — synced: catalog-era claims replaced with the current
+     active-plugin model; options philosophy corrected -->
+
 ## Purpose
 
 Personal Neovim configuration focused on modularity, extensibility, and maintainability. Designed for multi-language development with emphasis on lazy-loading performance and plugin ecosystem exploration.
@@ -8,8 +11,12 @@ Personal Neovim configuration focused on modularity, extensibility, and maintain
 
 ### For User
 
-- **Zero-startup overhead**: Plugins disabled by default, opt-in activation model
-- **Experimentation-friendly**: 330+ curated plugins available as exploration catalog
+- **Deferred-by-default startup**: every spec inherits `lazy = true`; nothing loads
+  without a trigger
+- **Portable across machines**: one config runs on Linux, WSL, Windows and macOS,
+  branching on detected capability rather than per-machine forks
+- **Experimentation-friendly**: plugins are vendored one-subdirectory-at-a-time and
+  can be parked with `cond = false` instead of deleted
 - **Multi-language support**: Dedicated LSP and filetype configurations for Rust, Haskell, Java, Go, TypeScript, etc.
 - **Task-driven workflow**: Automated daily routines (morning-routine: clean fetch → delete branches → pull → new patch branch)
 
@@ -26,8 +33,12 @@ Personal Neovim configuration focused on modularity, extensibility, and maintain
 - **Lazy.nvim foundation**: Modern plugin manager with auto-installation
 - **Lazy-by-default**: All plugins configured with `lazy = true`
 - **Active plugin specs**: Plugin imports enabled in `lua/config/lazy.lua` (plugins, colorschemes, denops-plugins)
-- **Colorscheme catalog**: 12 colorscheme options documented in `lua/colorschemes/colorschemes-list.md`
-- **Denops ecosystem**: Dedicated `lua/denops-plugins/` category for Denops-based plugins
+- **Scaffolded vendoring**: `task plugin-setup -- <url>` clones the source and lays
+  down the spec skeleton, so adding a plugin is a filled-in template, not a blank file
+- **Colorscheme catalog**: candidates tracked in `lua/colorschemes/colorschemes-list.md`;
+  active theme is tokyonight
+- **Denops ecosystem**: Dedicated `lua/denops-plugins/` category, gated off by default
+  and enabled only on machines with Deno (`lua/config/denops.lua`)
 
 ### Development Environment
 
@@ -52,15 +63,20 @@ Personal Neovim configuration focused on modularity, extensibility, and maintain
 
 ### Maintainability
 
-- Clear module boundaries (after/ftplugin, after/lsp, lua/plugins, lua/colorschemes)
+- Clear module boundaries (lua/config one-concern modules, after/ftplugin, after/lsp,
+  lua/plugins, lua/colorschemes)
+- Silent-failure classes caught by drift guards (`task check-keys`, `task check-options-sync`)
+  rather than by review
 - TODOs tracked in place (rust-analyzer, LSP configs)
-- EditorConfig enforcement
+- EditorConfig + StyLua + Selene enforcement, all clean
 
 ### User Experience
 
-- Minimal default configuration (only essential options)
+- Explicit configuration over implicit defaults: `lua/config/options.lua` states every
+  option, so "unset" is a visible decision rather than an omission
 - Progressive disclosure (start minimal, enable features as needed)
-- Documentation accessibility (CLAUDE.md, neovim_tips/)
+- Documentation accessibility (CLAUDE.md, neovim_tips/, docs/, per-plugin notes under
+  `lua/plugins/docs/`)
 
 ## Active Plugins
 
@@ -69,6 +85,9 @@ Active plugins are cataloged in `lua/plugins/` (one subdirectory per plugin). Ru
 ## Out of Scope
 
 - Pre-configured IDE-like experience (user enables what they need)
-- Opinionated keybindings (minimal defaults: Space leader, double-Esc nohlsearch)
-- One-size-fits-all plugin selection (catalog approach over defaults)
+- Opinionated global keybindings — `lua/config/mappings.lua` holds only double-Esc
+  nohlsearch; everything else is scoped to the plugin that owns it via its `keys.lua`
+- One-size-fits-all plugin selection (vendor per plugin, park with `cond = false`)
+- Per-machine config forks — machine differences are expressed as capability checks
+  inside the one config
 

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -1,15 +1,28 @@
 # Project Structure
 
+<!-- updated_at: 2026-07-31 — synced with codebase: init.lua thinned to a loader,
+     lua/config/ split into single-responsibility modules, scripts/ + lint tooling added -->
+
 ## Directory Organization
 
 ```
-nvim-new/
-├── init.lua                      # Entry point: options, lazy.nvim bootstrap
+nvim/
+├── init.lua                      # Thin loader: vim.loader + require("config.*") chain
+├── filetype.lua                  # Neovim runtime filetype hook (vim.filetype.add)
 ├── lua/
-│   ├── config/
-│   │   └── lazy.lua             # Plugin manager configuration (specs active)
+│   ├── config/                  # One module per concern, all required from init.lua
+│   │   ├── host.lua             # Environment detection (single source of truth)
+│   │   ├── variables.lua        # vim.g.* — leader, providers, clipboard selection
+│   │   ├── options.lua          # Exhaustive vim.opt.* catalog (see tech.md)
+│   │   ├── clipboard.lua        # vim.g.clipboard provider tables
+│   │   ├── lazy.lua             # Plugin manager configuration (specs active)
+│   │   ├── autocmds.lua         # Global autocommands
+│   │   ├── mappings.lua         # Global keymaps (minimal)
+│   │   ├── usercmds.lua         # User commands
+│   │   ├── neovide.lua          # Neovide-only GUI settings
+│   │   └── denops.lua           # Returns bool: denops allowlist gate
 │   ├── plugins/
-│   │   ├── Integrations-memo.md # Integration notes and research
+│   │   ├── docs/                # Per-plugin research notes (see below)
 │   │   ├── <plugin-name>/       # Each plugin in its own subdirectory
 │   │   │   ├── init.lua         # Main spec (required)
 │   │   │   ├── opts.lua         # Configuration options
@@ -21,27 +34,36 @@ nvim-new/
 │   │   │   └── builds.lua       # Build commands
 │   │   └── ...
 │   ├── colorschemes/
-│   │   ├── colorschemes-list.md # 12 colorscheme catalog
+│   │   ├── colorschemes-list.md # Colorscheme catalog (wishlist, not installed set)
 │   │   └── <theme-name>/        # Same subdirectory pattern as plugins
-│   └── denops-plugins/          # Denops-based plugins (separate category)
-│       └── <plugin-name>/       # Same subdirectory pattern
+│   ├── denops-plugins/          # Denops-based plugins (separate category)
+│   │   └── <plugin-name>/       # Same subdirectory pattern
+│   └── milli/                   # Plugin-owned data modules (e.g. splash art)
 ├── after/
 │   ├── ftplugin/                # Language-specific settings
 │   │   ├── rust.lua             # Rust (TODO: rust-analyzer)
 │   │   ├── haskell.lua          # Haskell
 │   │   ├── java.lua             # Java
 │   │   └── cabal.lua            # Cabal
-│   └── lsp/                     # LSP server configurations
+│   └── lsp/                     # LSP server configs — return vim.lsp.Config
 │       ├── yamlls.lua           # YAML (TODO)
 │       ├── jsonls.lua           # JSON (TODO)
 │       ├── taplo.lua            # TOML (TODO)
 │       └── helm_ls.lua          # Helm (TODO)
+├── scripts/                     # Headless-Neovim guard scripts + shell wrappers
+│   ├── check-keys-spec.{lua,sh}     # Lint lua/**/keys.lua for LazyKeysSpec shape
+│   ├── check-options-sync.{lua,sh}  # Detect options.lua vs Neovim option-set drift
+│   ├── nvim-plugin-clone.sh         # Vendor a plugin + scaffold its spec
+│   └── nvim-worktree.sh             # Parallel config worktrees via NVIM_APPNAME
+├── docs/                        # Repo-level design notes and plans/
 ├── snippets/                    # Traditional snippet format
 ├── luasnippets/                 # LuaSnip format
 ├── vscode-snippets/             # VSCode format
 ├── templates/                   # File templates
 ├── neovim_tips/                 # Personal notes
 ├── Taskfile.yml                 # Task automation
+├── selene.toml + selene/        # Lua linter config + Neovim std globals
+├── .stylua.toml                 # Lua formatter config
 ├── .editorconfig                # Code style enforcement
 └── CLAUDE.md                    # Project documentation (AI guidance)
 ```
@@ -49,28 +71,46 @@ nvim-new/
 ## Module Loading Flow
 
 ### Initialization Chain
-1. **init.lua** - Bootstrap environment
-   - Enable `vim.loader` (Lua module cache)
-   - Set global options (UI, encoding, providers)
-   - Define leader keys
-   - Load `require("config.lazy")` (line 33)
-   - Register DVC filetype detection
 
-2. **lua/config/lazy.lua** - Plugin manager setup
-   - Auto-install lazy.nvim if missing (lines 1-14)
-   - Configure lazy.nvim with defaults
-   - **Active imports**: `plugins`, `colorschemes`, `denops-plugins` (line 25-27)
+`init.lua` holds **no configuration of its own** — it enables `vim.loader`, requires
+each `config.*` module in a fixed order, then sets the colorscheme. Anything new
+belongs in the module that owns that concern, not in `init.lua`.
 
-3. **after/** - Post-configuration (loaded after init)
+1. **init.lua** — load order (order matters):
+   `config.variables` → `config.options` → `config.lazy` → `config.autocmds`
+   → `config.mappings` → `config.usercmds` → `config.neovide` → `vim.cmd.colorscheme`
+   - `variables` before `options`: leader keys must exist before mappings are defined
+   - `lazy` before `autocmds`/`mappings`: plugin specs may register their own
+
+2. **filetype.lua** (repo root) — sourced by Neovim's own runtime filetype
+   mechanism, before `after/ftplugin`. Extension/filename/pattern rules live here;
+   pattern rules that must beat a built-in need an explicit `priority`.
+
+3. **lua/config/lazy.lua** — plugin manager setup
+   - Auto-install lazy.nvim if missing
+   - **Active imports**: `plugins`, `colorschemes`, `denops-plugins`
+
+4. **after/** — post-configuration (loaded after init)
    - `ftplugin/*.lua` - Filetype-specific settings
    - `lsp/*.lua` - LSP server configurations
+
+### config/ Module Boundaries
+
+Each `lua/config/*.lua` owns exactly one concern and is required by name. Two of
+them are **libraries rather than steps** — they return a value instead of applying
+settings, and are required from wherever they are needed:
+
+- `config.host` → table of environment predicates (`is_windows()`, `is("azusa")`,
+  `is_human_rights()`, `paths.*`). Never re-detect host/OS anywhere else.
+- `config.clipboard` → named provider tables; `config.variables` picks one.
+- `config.denops` → a single boolean, used as `cond`/`enabled` in denops specs.
 
 ### Import Patterns
 
 #### Lazy.nvim Spec Import (Active)
 
 ```lua
--- lua/config/lazy.lua:24-28
+-- lua/config/lazy.lua
 spec = {
   { import = "plugins" },
   { import = "colorschemes" },
@@ -86,7 +126,7 @@ Imports all `init.lua` files from:
 #### Module Require Pattern
 
 ```lua
--- init.lua:33
+-- init.lua — every config module is required by dotted path, never by file path
 require("config.lazy")  -- Loads lua/config/lazy.lua
 ```
 
@@ -123,34 +163,43 @@ require("config.lazy")  -- Loads lua/config/lazy.lua
 ### init.lua Structure
 
 ```
-1. Performance (vim.loader)
-2. UI Options (termguicolors, mouse, number)
-3. File Handling (fileformats, fileencodings)
-4. Provider Disablement (Perl, Python, Ruby, Node)
-5. User Options (clipboard, leader keys)
-6. Plugin Manager (require config.lazy)
-7. Colorscheme (commented out)
-8. Keymaps (minimal: Esc-Esc nohlsearch)
-9. Filetype Detection (DVC autocmd)
+1. Performance      vim.loader.enable()
+2. config.variables vim.g.* — leader, providers, clipboard selection
+3. config.options   exhaustive vim.opt.* catalog
+4. config.lazy      plugin manager + spec imports
+5. config.autocmds  global autocommands
+6. config.mappings  global keymaps (Esc-Esc nohlsearch only)
+7. config.usercmds  user commands
+8. config.neovide   GUI settings, no-ops outside Neovide
+9. Colorscheme      vim.cmd.colorscheme("tokyonight")
 ```
+
+Nothing else lives here. New behaviour goes into the module that owns the concern —
+if none fits, add a module and insert it in this list.
 
 ### lazy.lua Structure
 
 ```
-1. Bootstrap (auto-install lazy.nvim)
-2. Runtime Path Prepend
-3. Local Leader Definition
-4. lazy.setup() Configuration:
-   - root: Plugin installation directory
+1. require("config.host")
+2. Bootstrap (auto-install lazy.nvim)
+3. Runtime Path Prepend
+4. Local Leader Definition
+5. Concurrency (host-derived)
+6. lazy.setup() Configuration:
+   - root / lockfile / state / pkg.cache / rocks.root / readme.root  (paths)
    - defaults: lazy = true
-   - spec: Plugin/colorscheme imports (disabled)
-   - lockfile: Version pinning
-   - concurrency: Platform-specific
-   - git: Throttle and cooldown settings
-   - performance: Disabled plugins
-   - ui: Nerd Font icons
-   - checker: Auto-update disabled
+   - spec: plugins, colorschemes, denops-plugins imports (active)
+   - concurrency: host-specific
+   - git: throttle disabled, cooldown 0
+   - dev: local plugin override path (~/projects)
+   - install / ui / diff: fallback colorscheme, Nerd Font icons, diff command
+   - performance: disabled built-in plugins
+   - checker: auto-update disabled
+   - profiling: loader + require enabled
 ```
+
+**Note**: `maplocalleader` is set here rather than in `variables.lua` — lazy.nvim
+requires both leaders to be defined before `setup()` runs.
 
 ### after/ Organization
 
@@ -165,11 +214,17 @@ require("config.lazy")  -- Loads lua/config/lazy.lua
 
 ```
 init.lua
-  └─> require("config.lazy")
+  └─> require("config.variables") ──> require("config.clipboard")
+  └─> require("config.options")   ──> require("config.host")
+  └─> require("config.lazy")      ──> require("config.host")
         └─> imports lua/plugins/<name>/init.lua (active)
         └─> imports lua/colorschemes/<name>/init.lua (active)
         └─> imports lua/denops-plugins/<name>/init.lua (active)
+              └─> require("config.denops") as cond/enabled gate
 ```
+
+`config.host` is the leaf everything else depends on — it must stay free of
+requires into the rest of the config.
 
 ### Side Loading
 
@@ -238,7 +293,28 @@ Active plugins live in `lua/plugins/<name>/` — run `ls lua/plugins/` for the f
 
 ## Documentation Pattern
 
-Integration notes and research for each plugin are kept in `lua/plugins/docs/Integrations/<plugin-name>.md`. These are per-plugin Markdown files that document integration considerations, configuration options researched, and usage notes. This replaces the previous single `Integrations-memo.md` file.
+Research notes live next to what they describe, one Markdown file per subject:
+
+- `lua/plugins/docs/<Category>/<plugin-name>.md` — per-plugin integration notes:
+  options researched, conflicts, usage. Categories are created as needed
+  (`Integrations/`, `Motions/`). Replaces the old single `Integrations-memo.md`.
+- `docs/<topic>.md` — repo-level design notes that span plugins (e.g. a config
+  module's rationale).
+- `docs/plans/<topic>.md` — comparison/decision documents written before a change
+  (e.g. evaluating competing plugins).
+
+## Quality Tooling
+
+Lint and format config sits at the repo root; the guard scripts run headless Neovim
+so they see the real option/spec surface rather than parsing text.
+
+- `.stylua.toml` — formatting (2-space, 120 col, double quotes)
+- `selene.toml` + `selene/globals.toml` — Lua lint with a Neovim std definition.
+  `shadowing` and `mixed_table` are allowed on purpose: lazy.nvim specs are
+  positional-plus-named by design.
+- `task check-keys` (`ck`) — rejects nested `opts` tables in `lua/**/keys.lua`
+- `task check-options-sync` (`cos`) — flags options added/removed by a Neovim
+  upgrade that `lua/config/options.lua` has not caught up with
 
 ## Anti-Patterns to Avoid
 
@@ -247,6 +323,11 @@ Integration notes and research for each plugin are kept in `lua/plugins/docs/Int
 - **Don't**: Put runtime logic in `lua/plugins/*.lua` (use `config` function)
 - **Don't**: Create `plugin/` directory (conflicts with lazy loading)
 - **Don't**: Use `require()` for optional modules without pcall
+- **Don't**: Add configuration to `init.lua` — it is a loader; put it in the owning
+  `lua/config/*.lua` module
+- **Don't**: Re-detect hostname / OS / WSL inline — call `config.host`
+- **Don't**: Define filetype rules in `autocmds.lua` when `filetype.lua` can express
+  them (the runtime hook is faster and beats `after/ftplugin` ordering surprises)
 
 ## Maintenance Patterns
 
@@ -258,13 +339,30 @@ Integration notes and research for each plugin are kept in `lua/plugins/docs/Int
 
 ### Enabling Plugin
 
-1. Create `lua/plugins/<name>/init.lua` with LazySpec (imports already active)
+1. `task plugin-setup -- <git-url>` scaffolds the subdirectory and spec skeleton
+   (or create `lua/plugins/<name>/init.lua` by hand — imports are already active)
 2. Restart Neovim (lazy.nvim auto-installs)
-3. To disable a plugin without removing: set `--cond = false` or `--enabled = false` in spec
+3. To disable a plugin without removing: set `cond = false` or `enabled = false` in spec
+4. Run `task check-keys` if the plugin ships a `keys.lua`
+
+### Adding a config Concern
+
+1. Create `lua/config/<concern>.lua`; if it *applies* settings, `require` it from
+   `init.lua` at the right point in the order — if it *returns* a value, leave
+   `init.lua` alone and require it from consumers
+2. Route any environment branch through `config.host` rather than a new detection
+
+### Working on Another Branch in Parallel
+
+Use `scripts/nvim-worktree.sh` (`/nvim-worktree`) rather than switching branches —
+each worktree gets `~/.config/nvim-<name>` with its own `NVIM_APPNAME`, so plugin
+and data dirs stay isolated.
 
 ### Task Automation
 
 1. Add task to `Taskfile.yml` under `tasks:` section
 2. Use `task <name>` or `task <alias>` to run
 3. Chain tasks with `task: <dependency>`
+4. Long logic goes in `scripts/` with a thin `.sh` wrapper the task calls; keep
+   Taskfile entries to one line
 

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -1,5 +1,8 @@
 # Technical Architecture
 
+<!-- updated_at: 2026-07-31 — synced: host.lua single-source-of-truth, exhaustive
+     options.lua, clipboard/denops gating, lint + drift-guard tooling -->
+
 ## Technology Stack
 
 ### Core Framework
@@ -13,6 +16,17 @@
 - **Lua**: Primary configuration language (init.lua, module system)
 - **YAML**: Task automation (Taskfile.yml)
 - **EditorConfig**: Cross-editor style enforcement
+- **TOML**: Tooling config (selene.toml, .stylua.toml)
+
+### Quality Tooling
+
+- **StyLua**: Formatter — 2 spaces, 120 columns, double quotes, no statement collapse
+- **Selene**: Lua linter with a project-local `selene/globals.toml` std for Neovim.
+  `shadowing` and `mixed_table` deliberately allowed (lazy.nvim specs are mixed by design)
+- **Headless-Neovim guard scripts** (`scripts/*.lua`, run via `task`): correctness
+  checks that need the real Neovim runtime rather than static parsing
+- **Neowright**: drives a real Neovim instance for UI/plugin debugging
+  (`.neowright/` sessions and snapshots, gitignored)
 
 ## Architecture Decisions
 
@@ -50,21 +64,64 @@
 **Decision**: Disable Perl, Python3, Ruby, Node providers
 **Rationale**: Faster startup, reduce external dependencies
 **Trade-offs**: Plugins requiring these providers won't work
-**Implementation**: `init.lua:26-29` - `vim.g.loaded_*_provider = 0`
+**Implementation**: `lua/config/variables.lua` - `vim.g.loaded_*_provider = 0`
 
 ### Performance Optimizations
 
 **Decision**: Disable built-in plugins (gzip, netrw, matchparen, etc.)
 **Rationale**: Reduce startup overhead, modern alternatives available
 **Trade-offs**: Users must install plugin alternatives (e.g., neo-tree for netrw)
-**Implementation**: `lua/config/lazy.lua:104-113` - `performance.rtp.disabled_plugins`
+**Implementation**: `lua/config/lazy.lua` - `performance.rtp.disabled_plugins`
 
-### Windows-Specific Concurrency
+### init.lua as a Pure Loader
 
-**Decision**: 2x CPU cores for git operations on Windows
-**Rationale**: Mitigate Windows filesystem performance issues
-**Trade-offs**: Higher resource usage on Windows
-**Implementation**: `lua/config/lazy.lua:30` - conditional concurrency
+**Decision**: `init.lua` contains no settings — only `vim.loader`, an ordered chain of
+`require("config.*")`, and the colorscheme call
+**Rationale**: A single growing entry point was the original failure mode; one module
+per concern makes each independently reviewable and greppable
+**Trade-offs**: Load order becomes load-bearing and implicit (see structure.md)
+**Implementation**: `init.lua`
+
+### Environment Detection in One Module
+
+**Decision**: All host / OS / WSL / hardware branching goes through `config.host`,
+which resolves and caches everything at load time
+**Rationale**: Detection was previously duplicated inline and drifted between call
+sites; predicates like `host.is("azusa")` read as intent, `jit.os:find(...)` does not
+**Trade-offs**: Values are constant for the session — anything that can change at
+runtime does not belong here
+**Implementation**: `lua/config/host.lua`; also carries `config_version` and
+`paths.*` (stdpath-derived absolute paths)
+
+### Capability Gating over Host Allowlists
+
+**Decision**: Gate features on the capability actually required, not on a machine name
+**Rationale**: Hostname allowlists break silently on every new machine
+**Examples**:
+
+- Clipboard: selected from `$WAYLAND_DISPLAY` + `executable("wl-copy")`, not hostname.
+  Forcing `wl-clipboard` where no Wayland server exists blocks startup on `wl-copy`'s
+  daemon (`lua/config/variables.lua` + `lua/config/clipboard.lua`)
+- Heavy plugin set: `host.is_human_rights()` compares total RAM against an OS-specific
+  threshold
+**Exception**: `config.denops` is an explicit `{ os, host }` allowlist — Deno is an
+external runtime whose presence cannot be probed cheaply at startup
+
+### Concurrency Tuning
+
+**Decision**: `concurrency = 4` on host `azusa`; 2× parallelism on Windows; default elsewhere
+**Rationale**: Windows filesystem overhead; `azusa` is resource-constrained
+**Implementation**: `lua/config/lazy.lua` via `host.is_azusa()`
+
+### Filetype Rules in the Runtime Hook
+
+**Decision**: Prefer root `filetype.lua` (`vim.filetype.add`) over `BufRead` autocmds
+**Rationale**: Runs in Neovim's own filetype resolution, so it is faster and ordering
+against built-ins is explicit via `priority`
+**Trade-offs**: Beating a built-in pattern requires knowing to set `priority`
+**Implementation**: `filetype.lua` — e.g. `%.?env%..*` → `dotenv` at priority 10, which
+outranks Neovim's built-in `.env.*` → `env`
+**Note**: `lua/config/autocmds.lua` still holds the DVC → yaml rule
 
 ### Git Throttling Disabled
 
@@ -168,10 +225,34 @@ local spec = {
 
 Denops-based plugins follow the same subdirectory pattern under `lua/denops-plugins/`.
 
+### Exhaustive, Self-Documenting options.lua
+
+**Decision**: `lua/config/options.lua` lists **every** Neovim option — set to its
+default, set to an override, or left commented out when it has no meaningful or
+portable default — each with a one-line comment
+**Rationale**: The file doubles as reference documentation; "not present" and
+"deliberately left alone" become distinguishable states
+**Trade-offs**: ~1200 lines, and a Neovim upgrade that adds or removes options
+silently makes it wrong — which is exactly what `task check-options-sync` guards
+**Implementation**: `lua/config/options.lua`, `scripts/check-options-sync.lua`
+
 ## Testing Strategy
 
-**Current Status**: No automated tests
-**Future Consideration**: Integration tests for critical workflows (lazy.nvim bootstrap, plugin loading)
+**Current Status**: No unit/integration test suite. Correctness is enforced by
+headless-Neovim drift guards rather than assertions:
+
+- `task check-keys` (`ck`) — `scripts/check-keys-spec.lua` walks `lua/**/keys.lua`
+  and rejects entries that nest options in a sub-table instead of naming them at the
+  top level. A `LazyKeysSpec` is `{ lhs, rhs?, desc = ..., silent = ... }`; the nested
+  form is accepted silently by Lua and then ignored by lazy.nvim
+- `task check-options-sync` (`cos`) — `scripts/check-options-sync.lua` diffs the
+  running Neovim's option set against `lua/config/options.lua`
+
+**Pattern**: when a class of mistake is silent at runtime, add a script under
+`scripts/` plus a `Taskfile.yml` entry rather than relying on review.
+
+**Future Consideration**: Integration tests for critical workflows (lazy.nvim
+bootstrap, plugin loading); Neowright already provides the harness.
 
 ## Dependency Management
 
@@ -190,8 +271,9 @@ Denops-based plugins follow the same subdirectory pattern under `lua/denops-plug
 
 ### Build Tools
 
-- **Task**: Task runner for git operations (Taskfile.yml)
-- **Git**: Version control + multi-remote push
+- **Task**: Task runner — git operations, plugin vendoring, drift guards (Taskfile.yml)
+- **Git**: Version control + multi-remote push (+ worktrees for parallel branches)
+- **Deno**: Required only by `lua/denops-plugins/*`, which are gated off by default
 
 ## Security Considerations
 
@@ -213,8 +295,12 @@ Denops-based plugins follow the same subdirectory pattern under `lua/denops-plug
 
 ## Known Limitations
 
-- Plugin catalog (plugins-list.md) still contains 330+ entries but only a subset have spec files
-- LSP servers installable via Mason (mason-nvim added), but LSP configs (after/lsp/*.lua) remain TODO
-- Snippets directories exist but no plugin integration configured
-- Templates exist but no plugin to use them
+- `after/lsp/*.lua` are all still empty `vim.lsp.Config` stubs marked TODO
+  (yamlls, jsonls, taplo, helm_ls); `after/ftplugin/rust.lua` likewise
+- `lua/colorschemes/colorschemes-list.md` is a **wishlist**, not the installed set —
+  only the schemes with a subdirectory are actually vendored
+- Snippets directories (`snippets/`, `luasnippets/`, `vscode-snippets/`) and
+  `templates/` exist but have no plugin wired to consume them
+- `host.paths.*` is populated but has no consumers yet (noted in the source)
+- No CI: lint, format, and drift guards run locally only
 


### PR DESCRIPTION
structure.md still described the pre-refactor layout: init.lua holding
options and keymaps, lua/config/ containing only lazy.lua, and a tree
rooted at nvim-new/. Five references pointed at line numbers that no
longer exist.

Rewrite the directory tree and initialization chain against the current
config, and document what the split introduced: the fixed require order
in init.lua, the distinction between config modules that apply settings
and the three that return values (host, clipboard, denops), and the
scripts/, docs/ and lint-config trees that were absent entirely.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>