### PR TITLE
fix: vendor specs into the right plugin tree

### DIFF
--- a/.claude/skills/add-plugin/SKILL.md
+++ b/.claude/skills/add-plugin/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: add-plugin
 description: >
-  Add new Neovim plugin(s) to this lazy.nvim config using
-  scripts/nvim-plugin-clone.sh. By default runs in **vendor-only** mode: it
-  vendors the plugin source and spec templates onto an add/<plugin> branch and
-  stops, leaving the spec `TODO` markers intact. Pass --fill to also complete
-  the lazy.nvim spec, verify it loads, and squash the wip commits. Use when the
-  user asks to add or install a Neovim plugin, e.g.
+  Add new Neovim plugin(s), colorscheme(s) or denops plugin(s) to this
+  lazy.nvim config using scripts/nvim-plugin-clone.sh. By default runs in
+  **vendor-only** mode: it vendors the source and spec templates onto an
+  add/<plugin> branch and stops, leaving the spec `TODO` markers intact. Pass
+  --fill to also complete the lazy.nvim spec, verify it loads, and squash the
+  wip commits. Use when the user asks to add or install a Neovim plugin, e.g.
   "/add-plugin https://github.com/author/plugin.nvim".
-argument-hint: "[--vendor-only | --fill] <git-url>..."
+argument-hint: "[--vendor-only | --fill] [--tree plugins|colorschemes|denops-plugins] <git-url>..."
 ---
 
 # Add a Neovim Plugin
@@ -30,6 +30,20 @@ the spec, verify it loads, and squash the wip commits into one clean commit.
 - **`--fill`** — do vendor-only, then steps 3–6: fill in the spec, verify it
   loads, squash the wip commits into one `feat:` commit, and hand off.
 
+## Target trees
+
+The config keeps three parallel plugin trees. Each spec requires its sibling
+files under a matching module prefix, so the tree must be decided **before**
+running the script — it selects the spec template and the vendoring target.
+
+| Tree | Directory | For |
+|---|---|---|
+| `plugins` (default) | `lua/plugins/` | ordinary Neovim plugins |
+| `colorschemes` | `lua/colorschemes/` | colorschemes |
+| `denops-plugins` | `lua/denops-plugins/` | denops (`vim-denops/denops.vim`) plugins |
+
+Throughout the rest of this document `<tree>` means the chosen directory name.
+
 ## 1. Parse & validate
 
 - **Mode flag**: scan `$ARGUMENTS` for a mode flag and strip it before treating
@@ -38,6 +52,17 @@ the spec, verify it loads, and squash the wip commits into one clean commit.
   - `--vendor-only`, or no flag → vendor-only mode (steps 1–2). **This is the
     default.**
   - If both flags appear, `--fill` wins.
+- **Tree flag**: scan for `--tree <name>` and strip it too. If absent, infer
+  the tree from the request and from the plugin itself:
+  - the user saying "colorscheme" / "テーマ" / "カラースキーム", or the repo
+    being a theme (`CODES/colors/*.vim|lua`, README showing palettes) →
+    `colorschemes`
+  - the repo depending on `vim-denops/denops.vim` (`CODES/denops/` directory)
+    → `denops-plugins`
+  - otherwise → `plugins`
+  - If the inference is uncertain and the URLs are a mixed batch, ask the user
+    which tree each belongs to rather than guessing. **One invocation vendors
+    into one tree**; run the skill again for a different tree.
 - Each remaining argument must be a git URL. If the user gave a bare
   `author/repo` slug, convert it to `https://github.com/author/repo.git` (the
   script rejects scheme-less values).
@@ -48,17 +73,31 @@ the spec, verify it loads, and squash the wip commits into one clean commit.
 - The script branches off the **current branch**. Check
   `git branch --show-current` first; if it is not `master` (or an up-to-date
   base the user intended), confirm with the user before running.
-- Run: `scripts/nvim-plugin-clone.sh <git-url>...`
-  (equivalent: `task plugin-setup -- <git-url>...`)
+- Run the task matching the tree — it sets `NVIM_PLUGINS_DIR` for you:
+  - `plugins` → `task plugin-setup -- <git-url>...`
+  - `colorschemes` → `task colorscheme-setup -- <git-url>...`
+  - `denops-plugins` → `task denops-plugin-setup -- <git-url>...`
+
+  Equivalent direct invocation (the bare script defaults to `lua/plugins`):
+
+  ```bash
+  NVIM_PLUGINS_DIR=~/.config/nvim/lua/<tree> scripts/nvim-plugin-clone.sh <git-url>...
+  ```
+
+- The script prints `INFO: target <dir> -> spec template <name>`. **Check that
+  line** — it confirms the tree actually in use before any cloning happens.
 - For each URL the script creates a branch `add/<dir-name>`
   (`<dir-name>` = repo name with `.` → `-`, e.g. `convy.nvim` → `convy-nvim`)
   containing:
   - an empty marker commit `feat: add <owner>/<repo>`
-  - `lua/plugins/<dir-name>/CODES/` — the plugin source, history stripped ("wip" commit)
-  - `lua/plugins/<dir-name>/WIKIS/` — the GitHub wiki, if one exists ("wip" commit)
+  - `lua/<tree>/<dir-name>/CODES/` — the plugin source, history stripped ("wip" commit)
+  - `lua/<tree>/<dir-name>/WIKIS/` — the GitHub wiki, if one exists ("wip" commit)
   - spec templates next to `CODES/`: `init.lua`, `cmds.lua`, `events.lua`,
     `keys.lua`, `opts.lua`, `ft.lua`, `dependencies.lua`, plus `stylua.toml`
     and `.editorconfig` ("wip" commit)
+  - `init.lua` is the variant for the chosen tree, with its `require()` prefix
+    and the repo slug already substituted. The other two init variants are not
+    copied — every finished spec has exactly one `init.lua`.
 - The script skips URLs whose branch or directory already exists — report any
   `SKIP:` lines to the user.
 - Vendored `CODES/`/`WIKIS/` stay in the branch; do not delete them.
@@ -82,37 +121,40 @@ sources** — `CODES/README.md`, `CODES/doc/*.txt`, `WIKIS/` — to find:
 - user commands, recommended keymaps, default/example opts,
   dependencies, and relevant filetypes
 
-Then edit the templates in `lua/plugins/<dir-name>/`, using a recently merged
-plugin such as `lua/plugins/convy-nvim/` as the finished-state reference:
+Then edit the templates in `lua/<tree>/<dir-name>/`, using a finished spec in
+the same tree as the reference — `lua/plugins/convy-nvim/` for plugins,
+`lua/colorschemes/tokyonight-nvim/` for colorschemes:
 
 - **`init.lua`** — placeholders are already substituted by the script.
-  - Delete every `denops-plugins.*` require variant (this skill targets
-    `lua/plugins/`); if the plugin is actually a denops plugin or a
-    colorscheme, stop and ask the user — it belongs elsewhere.
   - Uncomment only the lines the plugin needs (`cmd`, `keys`, `event`,
     `ft`, `dependencies`, `opts`/`config`). Leave unused optional lines
     commented, as existing specs do.
   - If the plugin needs `setup()`, use the `config = function()` form:
-    `local opts = require("plugins.<dir-name>.opts")` then
+    `local opts = require("<tree>.<dir-name>.opts")` then
     `require("<module>").setup(opts)`.
   - Change `cond = false` / `enabled = false` to their commented forms
     (`--cond = false` / `--enabled = false`) so the plugin is enabled.
+  - **Colorschemes only**: uncomment `lazy = false` and `priority = 1000` so
+    the theme loads before everything else, as `tokyonight-nvim` does.
   - Delete the trailing `-- :%s/...` helper comment line.
 - **`cmds.lua` / `events.lua` / `keys.lua` / `opts.lua` / `ft.lua` /
   `dependencies.lua`** — replace the `TODO` markers with real values,
   following the shape of existing specs. Before choosing a `<leader>`
-  mapping, grep `lua/plugins/*/keys.lua` for the same left-hand side and
-  pick a non-conflicting one.
+  mapping, grep **all three trees** for the same left-hand side and pick a
+  non-conflicting one:
+  `grep -rn '"<leader>x' lua/plugins lua/colorschemes lua/denops-plugins --include=keys.lua`
 - Delete spec files the plugin does not use (e.g. `ft.lua`,
   `dependencies.lua`) and keep their `init.lua` lines commented — merged
   plugins only keep the files they require.
 
 ## 4. Verify (`--fill` mode)
 
-- `stylua --check lua/plugins/<dir-name>/*.lua` — fix any issues
+- `stylua --check lua/<tree>/<dir-name>/*.lua` — fix any issues
   (do not run stylua over `CODES/`).
 - `nvim --headless "+Lazy! install <repo>" "+Lazy! load <repo>" +qa` — must
   load without errors. Debug and fix before reporting done.
+- For a colorscheme also confirm it applies:
+  `nvim --headless "+colorscheme <name>" +qa`.
 
 ## 5. Squash the wip commits (`--fill` mode)
 
@@ -121,11 +163,16 @@ empty marker commit (`<base>` is the branch the script ran from, usually
 `master`):
 
 ```bash
-git add -A lua/plugins/<dir-name>   # stage the spec edits from step 3
-marker="$(git log --format='%H %s' <base>..HEAD | awk '/feat: add/ {print $1; exit}')"
+git add -A lua/<tree>/<dir-name>   # stage the spec edits from step 3
+marker="$(git log --format='%H %s' <base>..HEAD | grep -m1 'feat: add' | cut -d' ' -f1)"
 git reset --soft "${marker}"
 git commit --amend -n --no-edit
 ```
+
+Note: extract the hash with `cut`, never with an awk positional field. This
+file is expanded with the invocation arguments before you read it, so a bare
+dollar-one inside a snippet is silently replaced by the first URL and the
+command becomes syntactically broken. Keep the pipeline `cut`-based.
 
 The branch must end up as a single `feat: add <owner>/<repo>` commit on top
 of the base branch. Verify with `git log --oneline master..HEAD`.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -90,6 +90,22 @@ tasks:
       - "{{.TASKFILE_DIR}}/scripts/nvim-plugin-clone.sh {{.CLI_ARGS}}"
     silent: true
 
+  colorscheme-setup:
+    desc: "Vendor colorscheme(s) into lua/colorschemes (usage: task colorscheme-setup -- <git-url>...)"
+    env:
+      NVIM_PLUGINS_DIR: "{{.TASKFILE_DIR}}/lua/colorschemes"
+    cmds:
+      - "{{.TASKFILE_DIR}}/scripts/nvim-plugin-clone.sh {{.CLI_ARGS}}"
+    silent: true
+
+  denops-plugin-setup:
+    desc: "Vendor denops plugin(s) into lua/denops-plugins (usage: task denops-plugin-setup -- <git-url>...)"
+    env:
+      NVIM_PLUGINS_DIR: "{{.TASKFILE_DIR}}/lua/denops-plugins"
+    cmds:
+      - "{{.TASKFILE_DIR}}/scripts/nvim-plugin-clone.sh {{.CLI_ARGS}}"
+    silent: true
+
   check-keys:
     desc: "Lint lua/**/keys.lua for LazyKeysSpec violations (nested opts tables)"
     aliases:

--- a/scripts/nvim-plugin-clone.sh
+++ b/scripts/nvim-plugin-clone.sh
@@ -16,15 +16,24 @@ set -euo pipefail
 #   4. lazy.nvim spec templates copied next to CODES/, as "wip"
 # Squash the wip commits into the marker commit via rebase before opening a PR.
 #
+# The spec templates ship three init variants, one per plugin tree, because
+# each requires its sibling spec files under a different module prefix
+# ("plugins.", "colorschemes.", "denops-plugins."). Only the variant matching
+# PLUGINS_DIR is installed, as init.lua; see init_template_for().
+#
 # Usage:
 #   nvim-plugin-clone <git-url>...
 #   task plugin-setup -- <git-url>...
+#   task colorscheme-setup -- <git-url>...
+#   task denops-plugin-setup -- <git-url>...
 #
 # Examples:
 #   nvim-plugin-clone https://github.com/xeind/vallow.nvim.git
 #   nvim-plugin-clone \
 #     https://github.com/ryanmab/onoma.nvim.git \
 #     https://github.com/zeybek/camouflage.nvim.git
+#   NVIM_PLUGINS_DIR=~/.config/nvim/lua/colorschemes \
+#     nvim-plugin-clone https://github.com/vague-theme/vague.nvim
 
 readonly TEMPLATE_DIR="${NVIM_PLUGIN_TEMPLATE_DIR:-${HOME}/NVIM_PLUGIN_TEMPLATES}"
 readonly PLUGINS_DIR="${NVIM_PLUGINS_DIR:-${HOME}/.config/nvim/lua/plugins}"
@@ -48,16 +57,44 @@ Runnable from any directory; override the target with NVIM_PLUGINS_DIR.
 EOF
 }
 
-# Usage: copy_templates <dir_name> <owner_repo>
+# Usage: init_template_for <plugins_dir>
+# Description: Echo the init template variant whose require() prefix matches
+#              the target plugin tree. Installing the wrong one leaves the
+#              spec requiring its siblings under a prefix that does not exist.
+# Returns: always 0
+init_template_for() {
+    local plugins_dir="${1:?Error: plugins_dir required}"
+
+    case "${plugins_dir##*/}" in
+        colorschemes) echo "init_colorschemes.lua" ;;
+        denops-plugins) echo "init_denops.lua" ;;
+        plugins) echo "init.lua" ;;
+        *)
+            echo "INFO: unknown target tree '${plugins_dir##*/}', using init.lua" >&2
+            echo "init.lua"
+            ;;
+    esac
+}
+
+# Usage: copy_templates <dir_name> <owner_repo> <init_template>
 # Description: Copy lazy.nvim spec templates into <dir_name>/ (excluding
-#              .git/.jj) and replace placeholders in init.lua
+#              .git/.jj), keep only <init_template> as init.lua, and replace
+#              placeholders in it
 # Returns: 0 on success, non-zero on error
 copy_templates() {
     local dir_name="${1:?Error: dir_name required}"
     local owner_repo="${2:?Error: owner_repo required}"
+    local init_template="${3:?Error: init_template required}"
 
     cp "${TEMPLATE_DIR}"/*.lua "${dir_name}/"
     cp "${TEMPLATE_DIR}/.editorconfig" "${TEMPLATE_DIR}/stylua.toml" "${dir_name}/"
+
+    # Finished specs carry exactly one init.lua in every tree, so drop the
+    # variants that do not apply here instead of shipping all three.
+    if [[ "${init_template}" != "init.lua" ]]; then
+        mv -f "${dir_name}/${init_template}" "${dir_name}/init.lua"
+    fi
+    rm -f "${dir_name}/init_colorschemes.lua" "${dir_name}/init_denops.lua"
 
     # Fill in the spec template for this plugin
     sed -i \
@@ -66,13 +103,14 @@ copy_templates() {
         "${dir_name}/init.lua"
 }
 
-# Usage: process_plugin <git_url> <base_branch>
+# Usage: process_plugin <git_url> <base_branch> <init_template>
 # Description: Create branch add/<dir>, vendor CODES/WIKIS, copy templates,
 #              and commit each step (empty feat marker, then wip commits)
 # Returns: 0 on success, 1 if skipped (existing branch/directory)
 process_plugin() {
     local url="${1:?Error: url required}"
     local base_branch="${2:?Error: base_branch required}"
+    local init_template="${3:?Error: init_template required}"
 
     # Normalize the URL: tolerate trailing slashes and a missing .git suffix.
     # A wiki URL (<repo>.wiki[.git]) is folded into its parent repository,
@@ -126,7 +164,7 @@ process_plugin() {
         echo "INFO: no wiki found for ${owner_repo}"
     fi
 
-    copy_templates "${dir_name}" "${owner_repo}"
+    copy_templates "${dir_name}" "${owner_repo}" "${init_template}"
     git add -f "${dir_name}"
     git commit -nm "wip"
 
@@ -165,9 +203,13 @@ main() {
         exit 1
     fi
 
+    local init_template
+    init_template="$(init_template_for "${PLUGINS_DIR}")"
+    echo "INFO: target ${PLUGINS_DIR} -> spec template ${init_template}"
+
     local url
     for url in "$@"; do
-        process_plugin "${url}" "${base_branch}" || true
+        process_plugin "${url}" "${base_branch}" "${init_template}" || true
     done
 
     echo


### PR DESCRIPTION
The spec templates ship three `init.lua` variants, one per plugin tree
(`lua/plugins`, `lua/colorschemes`, `lua/denops-plugins`), because each
requires its sibling spec files under a different module prefix.

`nvim-plugin-clone.sh` copied all three into every vendored directory and
substituted placeholders in `init.lua` only. Vendoring anywhere other than
`lua/plugins` therefore produced an `init.lua` requiring a `plugins.` prefix
that does not exist there, plus two unsubstituted leftovers to clean up by
hand. Every colorscheme vendored so far hit this.

## Changes

- **`scripts/nvim-plugin-clone.sh`** — pick the variant matching
  `NVIM_PLUGINS_DIR`, install it as `init.lua`, drop the other two. Unknown
  target directories warn and fall back to the `plugins` variant. The chosen
  template is echoed before any cloning happens.
- **`Taskfile.yml`** — add `colorscheme-setup` and `denops-plugin-setup`, so
  the target tree is picked by command name instead of by remembering to set
  `NVIM_PLUGINS_DIR`.
- **`.claude/skills/add-plugin/SKILL.md`** — the skill hardcoded `lua/plugins`
  and instructed the reader to delete the denops require variants and to stop
  if the plugin turned out to be a colorscheme, neither of which applies now.
  Add an explicit target tree with inference rules, route step 2 through the
  per-tree tasks, and generalise the paths. The keymap conflict grep now
  covers all three trees; checking only `lua/plugins` missed collisions with
  the other two.

  Also replaces the awk positional field in the squash snippet. The file is
  expanded with the invocation arguments before it is read, so that field
  reference was being substituted with a caller URL and the documented command
  could never run.

## Verification

Vendored `octocat/Hello-World` into a scratch repository against all three
trees plus an unknown one. Each produced exactly one `init.lua`, with the
repo slug substituted and the require prefix matching the tree; the fallback
warned and used `plugins.`. `shellcheck` clean, `task --list` parses.