### PR TITLE
feat: add willothy/nvim-cokeline

### DIFF
--- a/lua/plugins/nvim-cokeline/.editorconfig
+++ b/lua/plugins/nvim-cokeline/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+[*.lua]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/lua/plugins/nvim-cokeline/CODES/.github/FUNDING.yml
+++ b/lua/plugins/nvim-cokeline/CODES/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: [ "https://paypal.me/noib3", "https://paypal.me/willothy" ]

--- a/lua/plugins/nvim-cokeline/CODES/.github/configs/commitlint.config.js
+++ b/lua/plugins/nvim-cokeline/CODES/.github/configs/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ["@commitlint/config-conventional"] };

--- a/lua/plugins/nvim-cokeline/CODES/.github/workflows/commit-messages.yaml
+++ b/lua/plugins/nvim-cokeline/CODES/.github/workflows/commit-messages.yaml
@@ -1,0 +1,35 @@
+name: "Commit message check"
+on: [push, pull_request]
+jobs:
+  check-commit-message:
+    name: Ensure messages conform to Conventional Commits standard
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install required dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y git curl
+          curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+          sudo DEBIAN_FRONTEND=noninteractive apt install -y nodejs
+      - name: Print versions
+        run: |
+          git --version
+          node --version
+          npm --version
+          npx commitlint --version
+      - name: Install commitlint
+        run: |
+          npm install conventional-changelog-conventionalcommits
+          npm install commitlint@latest
+          npm install @commitlint/config-conventional
+
+      - name: Validate current commit (last commit) with commitlint
+        if: github.event_name == 'push'
+        run: npx commitlint --config ".github/configs/commitlint.config.js" --from HEAD~1 --to HEAD --verbose
+
+      - name: Validate PR commits with commitlint
+        if: github.event_name == 'pull_request'
+        run: npx commitlint --config ".github/configs/commitlint.config.js" --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/lua/plugins/nvim-cokeline/CODES/.github/workflows/lines.yaml
+++ b/lua/plugins/nvim-cokeline/CODES/.github/workflows/lines.yaml
@@ -1,0 +1,18 @@
+name: "Check line width"
+on: [push, pull_request]
+jobs:
+  # line-number:
+  #   name: Sloc < 1000
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - run: cargo install tokei
+  #     - run: num_sloc=$(tokei --type=Lua,'Vim script' --output=json . | jq .Total.code); if [ ${num_sloc} -gt 999 ]; then exit 1; fi
+
+  line-width:
+    name: Line width < 80 characters
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: cargo install --locked ripgrep
+      - run: max_line_width=$(rg --glob '*.{lua,vim}' --no-heading --no-filename --no-line-number . | awk '{print length}' | sort -n | tail -n 1); if [ ${max_line_width} -gt 79 ]; then exit 1; fi

--- a/lua/plugins/nvim-cokeline/CODES/.github/workflows/luacheck.yml
+++ b/lua/plugins/nvim-cokeline/CODES/.github/workflows/luacheck.yml
@@ -1,0 +1,19 @@
+name: Luacheck
+
+on:
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+    branches: [ "main", "master" ]
+
+  workflow_dispatch:
+
+
+jobs:
+  luacheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Luacheck
+        uses: lunarmodules/luacheck@v1.1.0

--- a/lua/plugins/nvim-cokeline/CODES/.github/workflows/panvimdoc.yml
+++ b/lua/plugins/nvim-cokeline/CODES/.github/workflows/panvimdoc.yml
@@ -1,0 +1,28 @@
+name: panvimdoc
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    name: pandoc to vimdoc
+    steps:
+      - uses: actions/checkout@v2
+      - uses: kdheepak/panvimdoc@main
+        with:
+          vimdoc: cokeline
+          version: "NVIM >=0.7"
+          toc: true
+          demojify: true
+          treesitter: true
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "chore(docs): autogenerate vimdoc"
+          branch: ${{ github.head_ref }}

--- a/lua/plugins/nvim-cokeline/CODES/.github/workflows/release.yml
+++ b/lua/plugins/nvim-cokeline/CODES/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: simple
+          package-name: nvim-cokeline

--- a/lua/plugins/nvim-cokeline/CODES/.gitignore
+++ b/lua/plugins/nvim-cokeline/CODES/.gitignore
@@ -1,0 +1,2 @@
+/doc/tags
+/TODO.md

--- a/lua/plugins/nvim-cokeline/CODES/.luacheckrc
+++ b/lua/plugins/nvim-cokeline/CODES/.luacheckrc
@@ -1,0 +1,23 @@
+ignore = {
+  "631",  -- max_line_length
+  --"212/_.*",  -- unused argument, for vars with "_" prefix
+  "212", -- Unused argument, In the case of callback function, _arg_name is easier to understand than _, so this option is set to off.
+  "121", -- setting read-only global variable 'vim'
+  "122", -- setting read-only field of global variable 'vim'
+}
+
+-- Global objects defined by the C code
+read_globals = {
+  "vim",
+}
+
+globals = {
+  "vim.g",
+  "vim.b",
+  "vim.w",
+  "vim.o",
+  "vim.bo",
+  "vim.wo",
+  "vim.go",
+  "vim.env"
+}

--- a/lua/plugins/nvim-cokeline/CODES/.luarc.json
+++ b/lua/plugins/nvim-cokeline/CODES/.luarc.json
@@ -1,0 +1,3 @@
+{
+    "workspace.checkThirdParty": false
+}

--- a/lua/plugins/nvim-cokeline/CODES/CHANGELOG.md
+++ b/lua/plugins/nvim-cokeline/CODES/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Changelog
+
+## [Unreleased](https://github.com/willothy/nvim-cokeline/tree/HEAD)
+
+[Full Changelog](https://github.com/willothy/nvim-cokeline/compare/v0.4.0...HEAD)
+
+**Merged pull requests:**
+
+- refactor: use modules, lazy requires [\#157](https://github.com/willothy/nvim-cokeline/pull/157) ([willothy](https://github.com/willothy))
+- fixup: \(3682c78e\): README: Replace `focused` with `fg` in default_hl [\#152](https://github.com/willothy/nvim-cokeline/pull/152) ([UtsavBalar1231](https://github.com/UtsavBalar1231))
+- feat!: support for more highlight attrs [\#150](https://github.com/willothy/nvim-cokeline/pull/150) ([willothy](https://github.com/willothy))
+- Update README.md [\#146](https://github.com/willothy/nvim-cokeline/pull/146) ([sashalikesplanes](https://github.com/sashalikesplanes))
+- feat: custom sorting functions [\#145](https://github.com/willothy/nvim-cokeline/pull/145) ([willothy](https://github.com/willothy))
+- feat: provide require\("cokeline.sidebar"\).get_width\(\) and cache sidebar widths [\#143](https://github.com/willothy/nvim-cokeline/pull/143) ([willothy](https://github.com/willothy))
+- refactor!: make scratch buffer if deleting last buffer [\#142](https://github.com/willothy/nvim-cokeline/pull/142) ([willothy](https://github.com/willothy))
+- feat: global \(per buffer/tab/etc\) hover events [\#140](https://github.com/willothy/nvim-cokeline/pull/140) ([willothy](https://github.com/willothy))
+
+## [v0.4.0](https://github.com/willothy/nvim-cokeline/tree/v0.4.0) (2023-07-02)
+
+[Full Changelog](https://github.com/willothy/nvim-cokeline/compare/v0.3.0...v0.4.0)
+
+**Merged pull requests:**
+
+- feat: sidebars on rhs of editor [\#138](https://github.com/willothy/nvim-cokeline/pull/138) ([willothy](https://github.com/willothy))
+- feat: native tab support [\#136](https://github.com/willothy/nvim-cokeline/pull/136) ([willothy](https://github.com/willothy))
+- perf: use stream-based iterators where possible [\#135](https://github.com/willothy/nvim-cokeline/pull/135) ([willothy](https://github.com/willothy))
+- Use named color names [\#134](https://github.com/willothy/nvim-cokeline/pull/134) ([lucassperez](https://github.com/lucassperez))
+- feat\(pick\): retain pick char order when not using filename [\#132](https://github.com/willothy/nvim-cokeline/pull/132) ([willothy](https://github.com/willothy))
+- feat: buffer history ringbuffer [\#131](https://github.com/willothy/nvim-cokeline/pull/131) ([willothy](https://github.com/willothy))
+- feat: support for passing highlight group names [\#130](https://github.com/willothy/nvim-cokeline/pull/130) ([nenikitov](https://github.com/nenikitov))
+- feat: allow multiple vert splits in sidebar [\#129](https://github.com/willothy/nvim-cokeline/pull/129) ([willothy](https://github.com/willothy))
+- fix: allow multibyte characters on buffer picker [\#123](https://github.com/willothy/nvim-cokeline/pull/123) ([lucassperez](https://github.com/lucassperez))
+- feat: add fallback icon by filetype [\#121](https://github.com/willothy/nvim-cokeline/pull/121) ([Webblitchy](https://github.com/Webblitchy))
+- fix: index update value [\#118](https://github.com/willothy/nvim-cokeline/pull/118) ([Equilibris](https://github.com/Equilibris))
+- feat: add fill_hl config option [\#114](https://github.com/willothy/nvim-cokeline/pull/114) ([FollieHiyuki](https://github.com/FollieHiyuki))
+- feat: Rearrange buffers with mouse drag [\#113](https://github.com/willothy/nvim-cokeline/pull/113) ([willothy](https://github.com/willothy))
+- feat\(pick\): release taken letters when deleting buffers [\#112](https://github.com/willothy/nvim-cokeline/pull/112) ([soifou](https://github.com/soifou))
+- feat: hover events [\#111](https://github.com/willothy/nvim-cokeline/pull/111) ([willothy](https://github.com/willothy))
+- feat: per-component click handlers [\#106](https://github.com/willothy/nvim-cokeline/pull/106) ([willothy](https://github.com/willothy))
+- feat: close by step and by index [\#104](https://github.com/willothy/nvim-cokeline/pull/104) ([willothy](https://github.com/willothy))
+- feat: handle click events with Lua, add bufdelete util [\#103](https://github.com/willothy/nvim-cokeline/pull/103) ([willothy](https://github.com/willothy))
+- Proposal: Add sorting by directory [\#97](https://github.com/willothy/nvim-cokeline/pull/97) ([ewok](https://github.com/ewok))
+- feat: `pick.use_filename` and `pick.letters` config options [\#88](https://github.com/willothy/nvim-cokeline/pull/88) ([ProspectPyxis](https://github.com/ProspectPyxis))
+- fix\(mapping\): handle gracefully keyboard interrupt on buffer pick. [\#81](https://github.com/willothy/nvim-cokeline/pull/81) ([soifou](https://github.com/soifou))
+- Update README.md [\#70](https://github.com/willothy/nvim-cokeline/pull/70) ([crivotz](https://github.com/crivotz))
+- Adding is_last and is_first to buffer return [\#69](https://github.com/willothy/nvim-cokeline/pull/69) ([miversen33](https://github.com/miversen33))
+- Add new configuration [\#68](https://github.com/willothy/nvim-cokeline/pull/68) ([danielnieto](https://github.com/danielnieto))
+- fix: check for Windows always fails when computing `unique_prefix` [\#65](https://github.com/willothy/nvim-cokeline/pull/65) ([EtiamNullam](https://github.com/EtiamNullam))
+- fix: cokeline-pick-close and cokeline-pick-focus in v0.7 [\#53](https://github.com/willothy/nvim-cokeline/pull/53) ([matt-riley](https://github.com/matt-riley))
+
+## [v0.3.0](https://github.com/willothy/nvim-cokeline/tree/v0.3.0) (2022-03-06)
+
+[Full Changelog](https://github.com/willothy/nvim-cokeline/compare/v0.2.0...v0.3.0)
+
+**Merged pull requests:**
+
+- fix: Allow focusing a buffer from a non-valid buffer [\#40](https://github.com/willothy/nvim-cokeline/pull/40) ([tamirzb](https://github.com/tamirzb))
+
+## [v0.2.0](https://github.com/willothy/nvim-cokeline/tree/v0.2.0) (2022-01-01)
+
+[Full Changelog](https://github.com/willothy/nvim-cokeline/compare/v0.1.0...v0.2.0)
+
+## [v0.1.0](https://github.com/willothy/nvim-cokeline/tree/v0.1.0) (2021-12-07)
+
+[Full Changelog](https://github.com/willothy/nvim-cokeline/compare/68b23cb77e2bf76df92a8043612e655e04507ed6...v0.1.0)
+
+**Merged pull requests:**
+
+- Update README.md [\#27](https://github.com/willothy/nvim-cokeline/pull/27) ([KadoBOT](https://github.com/KadoBOT))
+- Add author links to readme [\#20](https://github.com/willothy/nvim-cokeline/pull/20) ([alex-popov-tech](https://github.com/alex-popov-tech))
+- fix: correct error in readme.md [\#7](https://github.com/willothy/nvim-cokeline/pull/7) ([olimorris](https://github.com/olimorris))
+- :bug: fix: `unique_prefix` on windows [\#3](https://github.com/willothy/nvim-cokeline/pull/3) ([Neelfrost](https://github.com/Neelfrost))
+- :bug: fix: use correct path separators for unique_prefix depending on OS [\#2](https://github.com/willothy/nvim-cokeline/pull/2) ([Neelfrost](https://github.com/Neelfrost))
+
+\* _This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)_

--- a/lua/plugins/nvim-cokeline/CODES/LICENSE
+++ b/lua/plugins/nvim-cokeline/CODES/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Riccardo Mazzarini
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lua/plugins/nvim-cokeline/CODES/README.md
+++ b/lua/plugins/nvim-cokeline/CODES/README.md
@@ -1,0 +1,1111 @@
+<!-- panvimdoc-include-comment <br> -->
+<h1 align="center">
+  &#128067; nvim-cokeline
+</h1>
+<!-- panvimdoc-include-comment <br> -->
+
+<p align="center">
+<i>A Neovim bufferline for people with addictive personalities</i>
+</p>
+<!-- panvimdoc-include-comment <br> -->
+
+The goal of this plugin is not to be an opinionated bufferline with (more or
+less) limited customization options. Rather, it tries to provide a general
+framework allowing you to build **_your_** ideal bufferline, whatever that
+might look like.
+
+<!-- panvimdoc-ignore-start -->
+![preview](https://user-images.githubusercontent.com/38540736/226447816-c696153f-ccee-4e4a-8b6a-55e53ee737f8.png)
+
+## :book: Table of Contents
+
+- [Features](#sparkles-features)
+- [Requirements](#electric_plug-requirements)
+- [Installation](#package-installation)
+- [Configuration](#wrench-configuration)
+- [Mappings](#musical_keyboard-mappings)
+
+<!-- panvimdoc-ignore-end -->
+
+## :sparkles: Features
+
+### Endlessly customizable
+
+`nvim-cokeline` aims to be the most customizable bufferline plugin around. If
+you have an idea in mind of what your bufferline should look like, you should
+be able to make it look that way. If you can't, open an issue and we'll try to
+make it happen!
+
+<!-- panvimdoc-ignore-start -->
+Here's a (very limited) showcase of what it can be configured to look like
+(check out the wiki for more examples):
+
+<details>
+<summary>Click to see configuration</summary>
+
+```lua
+local get_hex = require('cokeline.hlgroups').get_hl_attr
+
+require('cokeline').setup({
+  default_hl = {
+    fg = function(buffer)
+      return
+        buffer.is_focused
+        and get_hex('ColorColumn', 'bg')
+         or get_hex('Normal', 'fg')
+    end,
+    bg = function(buffer)
+      return
+        buffer.is_focused
+        and get_hex('Normal', 'fg')
+         or get_hex('ColorColumn', 'bg')
+    end,
+  },
+
+  components = {
+    {
+      text = function(buffer) return ' ' .. buffer.devicon.icon end,
+      fg = function(buffer) return buffer.devicon.color end,
+    },
+    {
+      text = function(buffer) return buffer.unique_prefix end,
+      fg = get_hex('Comment', 'fg'),
+      italic = true
+    },
+    {
+      text = function(buffer) return buffer.filename .. ' ' end,
+      underline = function(buffer)
+        return buffer.is_hovered and not buffer.is_focused
+      end
+    },
+    {
+      text = '',
+      on_click = function(_, _, _, _, buffer)
+        buffer:delete()
+      end
+    },
+    {
+      text = ' ',
+    }
+  },
+})
+```
+
+</details>
+
+![cokeline-default](https://user-images.githubusercontent.com/38540736/226447806-0d4be251-788e-495c-abf7-ae5041dcc702.png)
+
+<details>
+<summary>Click to see configuration</summary>
+
+```lua
+local get_hex = require('cokeline.hlgroups').get_hl_attr
+
+local green = vim.g.terminal_color_2
+local yellow = vim.g.terminal_color_3
+
+require('cokeline').setup({
+  default_hl = {
+    fg = function(buffer)
+      return
+        buffer.is_focused
+        and get_hex('Normal', 'fg')
+         or get_hex('Comment', 'fg')
+    end,
+    bg = get_hex('ColorColumn', 'bg'),
+  },
+
+  components = {
+    {
+      text = '｜',
+      fg = function(buffer)
+        return
+          buffer.is_modified and yellow or green
+      end
+    },
+    {
+      text = function(buffer) return buffer.devicon.icon .. ' ' end,
+      fg = function(buffer) return buffer.devicon.color end,
+    },
+    {
+      text = function(buffer) return buffer.index .. ': ' end,
+    },
+    {
+      text = function(buffer) return buffer.unique_prefix end,
+      fg = get_hex('Comment', 'fg'),
+      italic = true,
+    },
+    {
+      text = function(buffer) return buffer.filename .. ' ' end,
+      bold = function(buffer) return buffer.is_focused end,
+    },
+    {
+      text = ' ',
+    },
+  },
+})
+```
+
+</details>
+
+![cokeline-noib3](https://user-images.githubusercontent.com/38540736/226447808-fc834732-efd1-4fd1-a0de-65ebea213d3f.png)
+
+<details>
+<summary>Click to see configuration</summary>
+
+```lua
+local get_hex = require('cokeline.hlgroups').get_hl_attr
+
+require('cokeline').setup({
+  default_hl = {
+    fg = function(buffer)
+      return
+        buffer.is_focused
+        and get_hex('Normal', 'fg')
+         or get_hex('Comment', 'fg')
+    end,
+    bg = 'NONE',
+  },
+  components = {
+    {
+      text = function(buffer) return (buffer.index ~= 1) and '▏' or '' end,
+      fg = function() return get_hex('Normal', 'fg') end
+    },
+    {
+      text = function(buffer) return '    ' .. buffer.devicon.icon end,
+      fg = function(buffer) return buffer.devicon.color end,
+    },
+    {
+      text = function(buffer) return buffer.filename .. '    ' end,
+      bold = function(buffer) return buffer.is_focused end
+    },
+    {
+      text = '󰖭',
+      on_click = function(_, _, _, _, buffer)
+        buffer:delete()
+      end
+    },
+    {
+      text = '  ',
+    },
+  },
+})
+```
+
+</details>
+
+![cokeline-bufferline-lua](https://user-images.githubusercontent.com/38540736/226447803-13f3d3ee-454f-42be-81b4-9254f95503e4.png)
+
+<!-- panvimdoc-ignore-end -->
+
+### Dynamic rendering
+
+<!-- ### Dynamic rendering (with sliders) -->
+
+Even when you have a lot of buffers open, `nvim-cokeline` is rendered to always
+keep the focused buffer visible and in the middle of the bufferline. Also, if a
+buffer doesn't fit entirely we still try to include as much of it as possible
+before cutting off the rest.
+
+<!-- panvimdoc-ignore-start -->
+
+![rendering](https://user-images.githubusercontent.com/38540736/226447817-4f3679c8-a10a-48ad-8329-b21c3ee54968.gif)
+
+<!-- panvimdoc-ignore-end -->
+
+### LSP support
+
+If a buffer has an LSP client attached to it, you can configure the style of a
+component to change based on how many errors, warnings, infos and hints are
+reported by the LSP.
+
+<!-- panvimdoc-ignore-start -->
+
+![lsp-styling](https://user-images.githubusercontent.com/38540736/226447813-4ec42530-9e86-43f5-98ed-fd7b4012120b.gif)
+
+<!-- panvimdoc-ignore-end -->
+
+### Buffer pick
+
+You can focus and close any buffer by typing its `pick_letter`. Letters are
+assigned by filename by default (e.g. `foo.txt` gets the letter `f`), and by
+keyboard reachability if the letter is already assigned to another buffer.
+
+<!-- panvimdoc-ignore-start -->
+
+<details>
+<summary>Click to see configuration</summary>
+
+```lua
+local is_picking_focus = require('cokeline.mappings').is_picking_focus
+local is_picking_close = require('cokeline.mappings').is_picking_close
+local get_hex = require('cokeline.hlgroups').get_hl_attr
+
+local red = vim.g.terminal_color_1
+local yellow = vim.g.terminal_color_3
+
+require('cokeline').setup({
+  default_hl = {
+    fg = function(buffer)
+      return
+        buffer.is_focused
+        and get_hex('Normal', 'fg')
+         or get_hex('Comment', 'fg')
+    end,
+    bg = function() return get_hex('ColorColumn', 'bg') end,
+  },
+
+  components = {
+    {
+      text = function(buffer) return (buffer.index ~= 1) and '▏' or '' end,
+    },
+    {
+      text = '  ',
+    },
+    {
+      text = function(buffer)
+        return
+          (is_picking_focus() or is_picking_close())
+          and buffer.pick_letter .. ' '
+           or buffer.devicon.icon
+      end,
+      fg = function(buffer)
+        return
+          (is_picking_focus() and yellow)
+          or (is_picking_close() and red)
+          or buffer.devicon.color
+      end,
+      italic = function()
+        return
+          (is_picking_focus() or is_picking_close())
+      end,
+      bold = function()
+        return
+          (is_picking_focus() or is_picking_close())
+      end
+    },
+    {
+      text = ' ',
+    },
+    {
+      text = function(buffer) return buffer.filename .. '  ' end,
+      bold = function(buffer) return buffer.is_focused end,
+    },
+    {
+      text = '',
+      on_click = function(_, _, _, _, buffer)
+        buffer:delete()
+      end,
+    },
+    {
+      text = '  ',
+    },
+  },
+})
+```
+
+</details>
+
+![buffer-pick](https://user-images.githubusercontent.com/38540736/226447793-8e2341b3-e454-49dc-af84-72d3b56f40d3.gif)
+
+<!-- panvimdoc-ignore-end -->
+
+### Sidebars
+
+You can add a left sidebar to integrate nicely with file explorer plugins like
+[nvim-tree.lua](https://github.com/nvim-tree/nvim-tree.lua),
+[CHADTree](https://github.com/ms-jpq/chadtree) or
+[NERDTree](https://github.com/preservim/nerdtree).
+
+<!-- panvimdoc-ignore-start -->
+
+<details>
+<summary>Click to see configuration</summary>
+
+```lua
+local get_hex = require('cokeline.hlgroups').get_hl_attr
+
+local yellow = vim.g.terminal_color_3
+
+require('cokeline').setup({
+  default_hl = {
+    fg = function(buffer)
+      return
+        buffer.is_focused
+        and get_hex('Normal', 'fg')
+         or get_hex('Comment', 'fg')
+    end,
+    bg = function() return get_hex('ColorColumn', 'bg') end,
+  },
+
+  sidebar = {
+    filetype = {'NvimTree', 'neo-tree'},
+    components = {
+      {
+        text = function(buf)
+          return buf.filetype
+        end,
+        fg = yellow,
+        bg = function() return get_hex('NvimTreeNormal', 'bg') end,
+        bold = true,
+      },
+    }
+  },
+
+  components = {
+    {
+      text = function(buffer) return (buffer.index ~= 1) and '▏' or '' end,
+    },
+    {
+      text = '  ',
+    },
+    {
+      text = function(buffer)
+        return buffer.devicon.icon
+      end,
+      fg = function(buffer)
+        return buffer.devicon.color
+      end,
+    },
+    {
+      text = ' ',
+    },
+    {
+      text = function(buffer) return buffer.filename .. '  ' end,
+      bold = function(buffer)
+        return buffer.is_focused
+      end,
+    },
+    {
+      text = '',
+      on_click = function(_, _, _, _, buffer)
+        buffer:delete()
+      end,
+    },
+    {
+      text = '  ',
+    },
+  },
+})
+```
+
+</details>
+
+![sidebars](https://user-images.githubusercontent.com/38540736/226447821-de543b87-909c-445f-ac6e-82f5f6bbf9aa.png)
+
+<!-- panvimdoc-ignore-end -->
+
+### Unique buffer names
+
+When files with the same filename belonging to different directories are opened
+simultaneously, you can include a unique filetree prefix to distinguish between
+them:
+
+<!-- panvimdoc-ignore-start -->
+
+![unique-prefix](https://user-images.githubusercontent.com/38540736/226447822-3315ad2f-35c9-4fc3-a777-c01cd8f2fe46.gif)
+
+<!-- panvimdoc-ignore-end -->
+
+### Clickable buffers
+
+Left click on a buffer to focus it, and right click to delete it. Alternatively, define custom click handlers for each component that override the default behavior.
+
+<!-- panvimdoc-ignore-start -->
+
+![clickable-buffers](https://user-images.githubusercontent.com/38540736/226447799-e845d266-0658-44e3-bd89-f706577844bf.gif)
+
+<!-- panvimdoc-ignore-end -->
+
+### Hover events
+
+Each component has access to an is_hovered property, and can be given custom `on_mouse_enter` and `on_mouse_leave` handlers, allowing for implementations of close buttons, diagnostic previews, and more complex funcionality.
+
+Note: requires `:h 'mousemoveevent'`
+
+<!-- panvimdoc-ignore-start -->
+
+![hover-events](https://github.com/willothy/nvim-cokeline/assets/38540736/fb92475f-d775-44fe-9c95-a76c1cbaf560)
+
+![hover-events-2](https://github.com/willothy/nvim-cokeline/assets/38540736/3b319c79-0bff-41dd-9a08-36fd627b3d08)
+
+<!-- panvimdoc-ignore-end -->
+
+### Buffer re-ordering (including mouse-drag reordering)
+
+<!-- panvimdoc-ignore-start -->
+
+![reordering](https://user-images.githubusercontent.com/38540736/226447818-bdf63d70-e153-4353-992d-d317a5764c09.gif)
+
+<!-- panvimdoc-ignore-end -->
+
+### Close icons
+
+<!-- panvimdoc-ignore-start -->
+
+![close-icons](https://user-images.githubusercontent.com/38540736/226447802-29b2919e-dd20-4789-8d6a-250d6d453c64.gif)
+
+<!-- panvimdoc-ignore-end -->
+
+### Buffer history tracking
+
+```lua
+require("cokeline.history"):last():focus()
+```
+
+If you are a user of [`resession.nvim`](https://github.com/stevearc/resession.nvim), cokeline's history will be restored along with
+the rest of your sessions.
+
+## :electric_plug: Requirements
+
+The two main requirements are Neovim 0.5+ and the `termguicolors` option to be
+set. If you want to display devicons in your bufferline you'll also need the
+[nvim-tree/nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons)
+plugin and a patched font (see [Nerd Fonts](https://www.nerdfonts.com/)).
+
+## :package: Installation
+
+### Lua
+
+#### With lazy.nvim
+
+```lua
+require("lazy").setup({
+  {
+  "willothy/nvim-cokeline",
+  dependencies = {
+    "nvim-tree/nvim-web-devicons", -- If you want devicons
+    "stevearc/resession.nvim"       -- Optional, for persistent history
+  },
+  config = true
+}
+})
+```
+
+### Vimscript
+
+If your config is still written in Vimscript and you use
+[vim-plug](https://github.com/junegunn/vim-plug):
+
+```vim
+call plug#begin('~/.config/nvim/plugged')
+  " ...
+  Plug 'nvim-tree/nvim-web-devicons' " If you want devicons
+  Plug 'willothy/nvim-cokeline'
+  " ...
+call plug#end()
+
+set termguicolors
+lua << EOF
+  require('cokeline').setup()
+EOF
+```
+
+## :wrench: Configuration
+
+> **note**<br>
+> Check out the [wiki](https://github.com/willothy/nvim-cokeline/wiki) for more details and API documentation.
+
+All the configuration is done by changing the contents of the Lua table passed to
+the `setup` function.
+
+The valid keys are:
+
+```lua
+require('cokeline').setup({
+  -- Only show the bufferline when there are at least this many visible buffers.
+  -- default: `1`.
+  ---@type integer
+  show_if_buffers_are_at_least = 1,
+
+  buffers = {
+    -- A function to filter out unwanted buffers. Takes a buffer table as a
+    -- parameter (see the following section for more infos) and has to return
+    -- either `true` or `false`.
+    -- default: `false`.
+    ---@type false | fun(buf: Buffer):boolean
+    filter_valid = false,
+
+    -- A looser version of `filter_valid`, use this function if you still
+    -- want the `cokeline-{switch,focus}-{prev,next}` mappings to work for
+    -- these buffers without displaying them in your bufferline.
+    -- default: `false`.
+    ---@type false | fun(buf: Buffer):boolean
+    filter_visible = false,
+
+    -- Which buffer to focus when a buffer is deleted, `prev` focuses the
+    -- buffer to the left of the deleted one while `next` focuses the one the
+    -- right.
+    -- default: 'next'.
+    focus_on_delete = 'prev' | 'next',
+
+    -- If set to `last` new buffers are added to the end of the bufferline,
+    -- if `next` they are added next to the current buffer.
+    -- if set to `directory` buffers are sorted by their full path.
+    -- if set to `number` buffers are sorted by bufnr, as in default Neovim
+    -- default: 'last'.
+    ---@type 'last' | 'next' | 'directory' | 'number' | fun(a: Buffer, b: Buffer):boolean
+    new_buffers_position = 'last',
+
+    -- If true, right clicking a buffer will close it
+    -- The close button will still work normally
+    -- Default: true
+    ---@type boolean
+    delete_on_right_click = true,
+  },
+
+  mappings = {
+    -- Controls what happens when the first (last) buffer is focused and you
+    -- try to focus/switch the previous (next) buffer. If `true` the last
+    -- (first) buffers gets focused/switched, if `false` nothing happens.
+    -- default: `true`.
+    ---@type boolean
+    cycle_prev_next = true,
+
+    -- Disables mouse mappings
+    -- default: `false`.
+    ---@type boolean
+    disable_mouse = false,
+  },
+
+  -- Maintains a history of focused buffers using a ringbuffer
+  history = {
+    ---@type boolean
+    enabled = true,
+    ---The number of buffers to save in the history
+    ---@type integer
+    size = 2
+  },
+
+  rendering = {
+    -- The maximum number of characters a rendered buffer is allowed to take
+    -- up. The buffer will be truncated if its width is bigger than this
+    -- value.
+    -- default: `999`.
+    ---@type integer
+    max_buffer_width = 999,
+  },
+
+  pick = {
+    -- Whether to use the filename's first letter first before
+    -- picking a letter from the valid letters list in order.
+    -- default: `true`
+    ---@type boolean
+    use_filename = true,
+
+    -- The list of letters that are valid as pick letters. Sorted by
+    -- keyboard reachability by default, but may require tweaking for
+    -- non-QWERTY keyboard layouts.
+    -- default: `'asdfjkl;ghnmxcvbziowerutyqpASDFJKLGHNMXCVBZIOWERTYQP'`
+    ---@type string
+    letters = 'asdfjkl;ghnmxcvbziowerutyqpASDFJKLGHNMXCVBZIOWERTYQP',
+  },
+
+  -- The default highlight group values.
+  -- The `fg`, `bg`, and `sp` keys are either colors in hexadecimal format or
+  -- functions taking a `buffer` parameter and returning a color in
+  -- hexadecimal format. Style attributes work the same way, but functions
+  -- should return boolean values.
+  default_hl = {
+    -- default: `ColorColumn`'s background color for focused buffers,
+    -- `Normal`'s foreground color for unfocused ones.
+    ---@type nil | string | fun(buffer: Buffer): string
+    fg = function(buffer)
+      local hlgroups = require("cokeline.hlgroups")
+      return buffer.is_focused and hlgroups.get_hl_attr("ColorColumn", "bg")
+        or hlgroups.get_hl_attr("Normal", "fg")
+    end,
+
+    -- default: `Normal`'s foreground color for focused buffers,
+    -- `ColorColumn`'s background color for unfocused ones.
+    -- default: `Normal`'s foreground color.
+    ---@type nil | string | function(buffer: Buffer): string,
+    bg = function(buffer)
+      local hlgroups = require("cokeline.hlgroups")
+      return buffer.is_focused and hlgroups.get_hl_attr("Normal", "fg")
+        or hlgroups.get_hl_attr("ColorColumn", "bg")
+    end,
+
+    -- default: unset.
+    ---@type nil | string | function(buffer): string,
+    sp = nil,
+
+    ---@type nil | boolean | fun(buf: Buffer):boolean
+    bold = nil,
+    ---@type nil | boolean | fun(buf: Buffer):boolean
+    italic = nil,
+    ---@type nil | boolean | fun(buf: Buffer):boolean
+    underline = nil,
+    ---@type nil | boolean | fun(buf: Buffer):boolean
+    undercurl = nil,
+    ---@type nil | boolean | fun(buf: Buffer):boolean
+    strikethrough = nil,
+  },
+
+  -- The highlight group used to fill the tabline space
+  fill_hl = 'TabLineFill',
+
+  -- A list of components to be rendered for each buffer. Check out the section
+  -- below explaining what this value can be set to.
+  -- default: see `/lua/cokeline/config.lua`
+  ---@type Component[]
+  components = {},
+
+  -- Custom areas can be displayed on the right hand side of the bufferline.
+  -- They act identically to buffer components, except their methods don't take a Buffer object.
+  -- If you want a rhs component to be stateful, you can wrap it in a closure containing state.
+  ---@type Component[] | false
+  rhs = {},
+
+  -- Tabpages can be displayed on either the left or right of the bufferline.
+  -- They act the same as other components, except they are passed TabPage objects instead of
+  -- buffer objects.
+  ---@type table | false
+  tabs = {
+    placement = "left" | "right",
+    ---@type Component[]
+    components = {}
+  },
+
+  -- Left sidebar to integrate nicely with file explorer plugins.
+  -- This is a table containing a `filetype` key and a list of `components` to
+  -- be rendered in the sidebar.
+  -- The last component will be automatically space padded if necessary
+  -- to ensure the sidebar and the window below it have the same width.
+  ---@type table | false
+  sidebar = {
+    ---@type string | string[]
+    filetype = { "NvimTree", "neo-tree", "SidebarNvim" },
+    ---@type Component[]
+    components = {},
+  },
+})
+```
+
+### So what's `function(buffer)`?
+
+Some of the configuration options can be functions that take a [`Buffer`](https://github.com/willothy/nvim-cokeline/wiki/Buffer) as a
+single parameter. This is useful as it allows users to set the values of
+components dynamically based on the buffer that component is being rendered
+for.
+
+The `Buffer` type is just a Lua table with the following keys:
+
+```lua
+Buffer = {
+  -- The buffer's order in the bufferline (1 for the first buffer, 2 for the
+  -- second one, etc.).
+  index = int,
+
+  -- The buffer's internal number as reported by `:ls`.
+  number = int,
+
+  ---@type boolean
+  is_focused = false,
+
+  ---@type boolean
+  is_modified = false,
+
+  ---@type boolean
+  is_readonly = false,
+
+  -- The buffer is the first visible buffer in the tab bar
+  ---@type boolean
+  is_first    = false,
+
+  -- The buffer is the last visible buffer in the tab bar
+  ---@type boolean
+  is_last     = false,
+
+  -- The mouse is hovering over the current component in the buffer
+  -- This is a special variable in that it will only be true for the hovered *component*
+  -- on render. This is to allow components to respond to hover events individually without managing
+  -- component state.
+  ---@type boolean
+  is_hovered  = false,
+
+  -- The mouse is hovering over the buffer (true for all components)
+  ---@type boolean
+  buf_hovered = false,
+
+  -- The buffer's type as reported by `:echo &buftype`.
+  ---@type string
+  ---@type string
+  type = '',
+
+  -- The buffer's filetype as reported by `:echo &filetype`.
+  ---@type string
+  filetype = '',
+
+  -- The buffer's full path.
+  ---@type string
+  path = '',
+
+  -- The buffer's filename.
+  ---@type string
+  filename = 'string',
+
+  -- A unique prefix used to distinguish buffers with the same filename
+  -- stored in different directories. For example, if we have two files
+  -- `bar/foo.md` and `baz/foo.md`, then the first will have `bar/` as its
+  -- unique prefix and the second one will have `baz/`.
+  ---@type string
+  unique_prefix = '',
+
+  -- The letter that is displayed when picking a buffer to either focus or
+  -- close it.
+  ---@type string
+  pick_letter = 'char',
+
+  -- This needs the `nvim-tree/nvim-web-devicons` plugin to be installed.
+  devicon = {
+    -- An icon representing the buffer's filetype.
+    ---@type string
+    icon = 'string',
+
+    -- The colors of the devicon in hexadecimal format (useful to be passed
+    -- to a component's `fg` field (see the `Components` section).
+    color = '#rrggbb',
+  },
+
+  -- The values in this table are the ones reported by Neovim's built in
+  -- LSP interface.
+  diagnostics = {
+    ---@type integer
+    errors = 0,
+    ---@type integer
+    warnings = 0,
+    ---@type integer
+    infos = 0,
+    ---@type integer
+    hints = 0,
+  },
+}
+```
+
+It also has methods that can be used in component event handlers:
+
+```lua
+---@param self Buffer
+---Deletes the buffer
+function Buffer:delete() end
+
+---@param self Buffer
+---Focuses the buffer
+function Buffer:focus() end
+
+---@param self Buffer
+---@return number
+---Returns the number of lines in the buffer
+function Buffer:lines() end
+
+---@param self Buffer
+---@return string[]
+---Returns the buffer's lines
+function Buffer:text() end
+
+---@param buf Buffer
+---@return boolean
+---Returns true if the buffer is valid
+function Buffer:is_valid() end
+```
+
+### What about [`TabPage`](https://github.com/willothy/nvim-cokeline/wiki/TabPage)s?
+
+Each method on a tab component is passed a `TabPage` object as an argument.
+
+`TabPage`, like `Buffer`, is simply a Lua table with some relevant data attached.
+
+```lua
+TabPage = {
+  -- The tabpage number, as reported by `nvim_list_tabpages`
+  ---@type integer
+  number = 0,
+  -- A list of Window objects contained in the TabPage (see wiki for more info)
+  ---@type Window[]
+  windows = {},
+  -- The currently focused window in the TabPage
+  ---@type Window
+  focused = nil,
+  -- True if the TabPage is the current TabPage
+  ---@type boolean
+  is_active = true,
+  -- True if the TabPage is first in the list
+  ---@type boolean
+  is_first = false,
+  -- True if the TabPage is last in the list
+  ---@type boolean
+  is_last = false
+}
+```
+
+### And [`components`](https://github.com/willothy/nvim-cokeline/wiki/Component)?
+
+You can configure what each buffer in your bufferline will be composed of by
+passing a list of components to the `setup` function.
+
+For example, let's imagine we want to construct a very minimal bufferline
+where the only things we're displaying for each buffer are its index, its
+filename and a close button.
+
+Then in our `setup` function we'd have:
+
+```lua
+require('cokeline').setup({
+  -- ...
+  components = {
+    {
+      text = function(buffer) return ' ' .. buffer.index end,
+    },
+    {
+      text = function(buffer) return ' ' .. buffer.filename .. ' ' end,
+    },
+    {
+      text = '󰅖',
+      on_click = function(_, _, _, _, buffer)
+        buffer:delete()
+      end
+    },
+    {
+      text = ' ',
+    }
+  }
+})
+```
+
+in this case every buffer would be composed of four components: the first
+displaying a space followed by the buffer index, the second one the filename
+padded by a space on each side, then a close button that allows us to
+`:bdelete` the buffer by left-clicking on it, and finally an extra space.
+
+This way of dividing each buffer into distinct components, combined with the
+ability to define every component's text and color depending on some property
+of the buffer we're rendering, allows for great customizability.
+
+Every component passed to the `components` list has to be a table of the form:
+
+```lua
+{
+
+  ---@type string | fun(buffer: Buffer): string
+  text = "",
+
+  -- The foreground, backgrond and style of the component
+  ---@type nil | string | fun(buffer: Buffer): string
+  fg = '#rrggbb',
+  ---@type nil | string | fun(buffer: Buffer): string
+  bg = '#rrggbb',
+  ---@type nil | string | fun(buffer: Buffer): string
+  sp = '#rrggbb',
+  ---@type nil | boolean | fun(buffer: Buffer): boolean
+  bold = false,
+  ---@type nil | boolean | fun(buffer: Buffer): boolean
+  italic = false,
+  ---@type nil | boolean | fun(buffer: Buffer): boolean
+  underline = false,
+  ---@type nil | boolean | fun(buffer: Buffer): boolean
+  undercurl = false,
+  ---@type nil | boolean | fun(buffer: Buffer): boolean
+  strikethrough = false,
+
+  -- Or, alternatively, the name of the highlight group
+  ---@type nil | string | fun(buffer: Buffer): string
+  highlight = nil,
+
+  -- If `true` the buffer will be deleted when this component is
+  -- left-clicked (usually used to implement close buttons, overrides `on_click`).
+  -- deprecated, it is recommended to use the Buffer:delete() method in an on_click event
+  -- to implement close buttons instead.
+  ---@type boolean
+  delete_buffer_on_left_click = false,
+
+  -- Handles click event for a component
+  -- If not set, component will have the default click behavior
+  -- buffer is a Buffer object, not a bufnr
+  ---@type nil | fun(idx: integer, clicks: integer, button: string, mods: string, buffer: Buffer)
+  on_click = nil,
+
+  -- Called on a component when hovered
+  ---@type nil | function(buffer: Buffer, mouse_col: integer)
+  on_mouse_enter = nil,
+
+  -- Called on a component when unhovered
+  ---@type nil | function(buffer: Buffer, mouse_col: integer)
+  on_mouse_leave = nil,
+
+  truncation = {
+    -- default: index of the component in the `components` table (1 for the
+    -- first component, 2 for the second, etc.).
+    ---@type integer
+    priority = 1,
+
+    -- default: `right`.
+    ---@type 'left' | 'middle' | 'right'
+    direction = 'left' | 'middle' | 'right',
+  },
+}
+```
+
+the `text` key is the only one that has to be set, all the others are optional
+and can be omitted.
+
+The `truncation` table controls what happens when a buffer is too long to be
+displayed in its entirety.
+
+More specifically, if a buffer's width (given by the sum of the widths of all
+its components) is bigger than the `rendering.max_buffer_width` config option,
+the buffer will be truncated.
+
+The default behaviour is truncate the buffer by dropping components from right
+to left, with the text of the last component that's included also being
+shortened from right to left. This can be modified by changing the values of
+the `truncation.priority` and `truncation.direction` keys.
+
+The `truncation.priority` controls the order in which components are dropped:
+the first component to be dropped will be the one with the lowest priority. If
+that's still not enough to bring the width of the buffer within the
+`rendering.max_buffer_width` limit, the component with the second lowest
+priority will be dropped, and so on. Note that a higher priority means a
+smaller integer value: a component with a priority of 5 will be dropped
+_after_ a component with a priority of 6, even though 6 > 5.
+
+The `truncation.direction` key simply controls from which direction a component
+is shortened. For example, you might want to set the `truncation.direction` of
+a component displaying a filename to `'middle'` or `'left'`, so that if
+the filename has to be shortened you'll still be able to see its extension,
+like in the following example (where it's set to `'left'`):
+
+<!-- panvimdoc-ignore-start -->
+
+![buffer-truncation](https://user-images.githubusercontent.com/38540736/226447798-6aee2e0f-f957-42ab-96dd-3618e78ba4ba.png)
+
+<!-- panvimdoc-ignore-end -->
+
+#### What about [`history`](https://github.com/willothy/nvim-cokeline/wiki/History)?
+
+The History keeps track of the buffers you access using a ringbuffer, and provides
+an API for accessing Buffer objects from the history.
+
+You can access the history using `require("cokeline.history")`, or through the global `_G.cokeline.history`.
+
+The `History` object provides these methods:
+
+```lua
+History = {}
+
+---Adds a Buffer object to the history
+---@type bufnr integer
+function History:push(bufnr)
+end
+
+---Removes and returns the oldest Buffer object in the history
+---@return Buffer?
+function History:pop()
+end
+
+---Returns a list of Buffer objects in the history,
+---ordered from oldest to newest
+---@return Buffer[]
+function History:list()
+end
+
+---Returns an iterator of Buffer objects in the history,
+---ordered from oldest to newest
+---@return fun(): Buffer?
+function History:iter()
+end
+
+---Get a Buffer object by history index
+---@param idx integer
+---@return Buffer?
+function History:get(idx)
+end
+
+---Get a Buffer object representing the last-accessed buffer (before the current one)
+---@return Buffer?
+function History:last()
+end
+
+---Returns true if the history is empty
+---@return boolean
+function History:is_empty()
+end
+
+---Returns the maximum number of buffers that can be stored in the history
+---@return integer
+function History:capacity()
+end
+
+---Returns true if the history contains the given buffer
+---@param bufnr integer
+---@return boolean
+function History:contains(bufnr)
+end
+
+---Returns the number of buffers in the history
+---@return integer
+function History:len()
+end
+```
+
+## :musical_keyboard: Mappings
+
+You can use the `mappings` module to create mappings from Lua:
+
+```lua
+vim.keymap.set("n", "<leader>bp", function()
+    require('cokeline.mappings').pick("focus")
+end, { desc = "Pick a buffer to focus" })
+```
+
+Alternatively, we expose the following `<Plug>` mappings which can be used as the right hand
+side of other mappings:
+
+```
+-- Focus the previous/next buffer
+<Plug>(cokeline-focus-prev)
+<Plug>(cokeline-focus-next)
+
+-- Switch the position of the current buffer with the previous/next buffer.
+<Plug>(cokeline-switch-prev)
+<Plug>(cokeline-switch-next)
+
+-- Focuses the buffer with index `i`.
+<Plug>(cokeline-focus-i)
+
+-- Switches the position of the current buffer with the buffer of index `i`.
+<Plug>(cokeline-switch-i)
+
+-- Focus a buffer by its `pick_letter`.
+<Plug>(cokeline-pick-focus)
+
+-- Close a buffer by its `pick_letter`.
+<Plug>(cokeline-pick-close)
+```
+
+A possible configuration could be:
+
+```lua
+local map = vim.api.nvim_set_keymap
+
+map("n", "<S-Tab>", "<Plug>(cokeline-focus-prev)", { silent = true })
+map("n", "<Tab>", "<Plug>(cokeline-focus-next)", { silent = true })
+map("n", "<Leader>p", "<Plug>(cokeline-switch-prev)", { silent = true })
+map("n", "<Leader>n", "<Plug>(cokeline-switch-next)", { silent = true })
+
+for i = 1, 9 do
+  map(
+    "n",
+    ("<F%s>"):format(i),
+    ("<Plug>(cokeline-focus-%s)"):format(i),
+    { silent = true }
+  )
+  map(
+    "n",
+    ("<Leader>%s"):format(i),
+    ("<Plug>(cokeline-switch-%s)"):format(i),
+    { silent = true }
+  )
+end
+
+```

--- a/lua/plugins/nvim-cokeline/CODES/doc/cokeline.txt
+++ b/lua/plugins/nvim-cokeline/CODES/doc/cokeline.txt
@@ -1,0 +1,766 @@
+*cokeline.txt*
+                                   For NVIM >=0.7    Last change: 2026 June 19
+
+==============================================================================
+Table of Contents                                 *cokeline-table-of-contents*
+
+  - Features                                               |cokeline-features|
+  - Requirements                                       |cokeline-requirements|
+  - Installation                                       |cokeline-installation|
+  - Configuration                                     |cokeline-configuration|
+  - Mappings                                               |cokeline-mappings|
+
+
+nvim-cokeline
+
+A Neovim bufferline for people with addictive personalities
+
+The goal of this plugin is not to be an opinionated bufferline with (more or
+less) limited customization options. Rather, it tries to provide a general
+framework allowing you to build **your** ideal bufferline, whatever that might
+look like.
+
+
+FEATURES                                                   *cokeline-features*
+
+
+ENDLESSLY CUSTOMIZABLE ~
+
+`nvim-cokeline` aims to be the most customizable bufferline plugin around. If
+you have an idea in mind of what your bufferline should look like, you should
+be able to make it look that way. If you can’t, open an issue and we’ll try
+to make it happen!
+
+
+DYNAMIC RENDERING ~
+
+Even when you have a lot of buffers open, `nvim-cokeline` is rendered to always
+keep the focused buffer visible and in the middle of the bufferline. Also, if a
+buffer doesn’t fit entirely we still try to include as much of it as possible
+before cutting off the rest.
+
+
+LSP SUPPORT ~
+
+If a buffer has an LSP client attached to it, you can configure the style of a
+component to change based on how many errors, warnings, infos and hints are
+reported by the LSP.
+
+
+BUFFER PICK ~
+
+You can focus and close any buffer by typing its `pick_letter`. Letters are
+assigned by filename by default (e.g. `foo.txt` gets the letter `f`), and by
+keyboard reachability if the letter is already assigned to another buffer.
+
+
+SIDEBARS ~
+
+You can add a left sidebar to integrate nicely with file explorer plugins like
+nvim-tree.lua <https://github.com/nvim-tree/nvim-tree.lua>, CHADTree
+<https://github.com/ms-jpq/chadtree> or NERDTree
+<https://github.com/preservim/nerdtree>.
+
+
+UNIQUE BUFFER NAMES ~
+
+When files with the same filename belonging to different directories are opened
+simultaneously, you can include a unique filetree prefix to distinguish between
+them:
+
+
+CLICKABLE BUFFERS ~
+
+Left click on a buffer to focus it, and right click to delete it.
+Alternatively, define custom click handlers for each component that override
+the default behavior.
+
+
+HOVER EVENTS ~
+
+Each component has access to an is_hovered property, and can be given custom
+`on_mouse_enter` and `on_mouse_leave` handlers, allowing for implementations of
+close buttons, diagnostic previews, and more complex funcionality.
+
+Note: requires |'mousemoveevent'|
+
+
+BUFFER RE-ORDERING (INCLUDING MOUSE-DRAG REORDERING) ~
+
+
+CLOSE ICONS ~
+
+
+BUFFER HISTORY TRACKING ~
+
+>lua
+    require("cokeline.history"):last():focus()
+<
+
+If you are a user of `resession.nvim`
+<https://github.com/stevearc/resession.nvim>, cokeline’s history will be
+restored along with the rest of your sessions.
+
+
+REQUIREMENTS                                           *cokeline-requirements*
+
+The two main requirements are Neovim 0.5+ and the `termguicolors` option to be
+set. If you want to display devicons in your bufferline you’ll also need the
+nvim-tree/nvim-web-devicons <https://github.com/nvim-tree/nvim-web-devicons>
+plugin and a patched font (see Nerd Fonts <https://www.nerdfonts.com/>).
+
+
+INSTALLATION                                           *cokeline-installation*
+
+
+LUA ~
+
+
+WITH LAZY.NVIM
+
+>lua
+    require("lazy").setup({
+      {
+      "willothy/nvim-cokeline",
+      dependencies = {
+        "nvim-tree/nvim-web-devicons", -- If you want devicons
+        "stevearc/resession.nvim"       -- Optional, for persistent history
+      },
+      config = true
+    }
+    })
+<
+
+
+VIMSCRIPT ~
+
+If your config is still written in Vimscript and you use vim-plug
+<https://github.com/junegunn/vim-plug>:
+
+>vim
+    call plug#begin('~/.config/nvim/plugged')
+      " ...
+      Plug 'nvim-tree/nvim-web-devicons' " If you want devicons
+      Plug 'willothy/nvim-cokeline'
+      " ...
+    call plug#end()
+    
+    set termguicolors
+    lua << EOF
+      require('cokeline').setup()
+    EOF
+<
+
+
+CONFIGURATION                                         *cokeline-configuration*
+
+
+  **note** Check out the wiki <https://github.com/willothy/nvim-cokeline/wiki>
+  for more details and API documentation.
+All the configuration is done by changing the contents of the Lua table passed
+to the `setup` function.
+
+The valid keys are:
+
+>lua
+    require('cokeline').setup({
+      -- Only show the bufferline when there are at least this many visible buffers.
+      -- default: `1`.
+      ---@type integer
+      show_if_buffers_are_at_least = 1,
+    
+      buffers = {
+        -- A function to filter out unwanted buffers. Takes a buffer table as a
+        -- parameter (see the following section for more infos) and has to return
+        -- either `true` or `false`.
+        -- default: `false`.
+        ---@type false | fun(buf: Buffer):boolean
+        filter_valid = false,
+    
+        -- A looser version of `filter_valid`, use this function if you still
+        -- want the `cokeline-{switch,focus}-{prev,next}` mappings to work for
+        -- these buffers without displaying them in your bufferline.
+        -- default: `false`.
+        ---@type false | fun(buf: Buffer):boolean
+        filter_visible = false,
+    
+        -- Which buffer to focus when a buffer is deleted, `prev` focuses the
+        -- buffer to the left of the deleted one while `next` focuses the one the
+        -- right.
+        -- default: 'next'.
+        focus_on_delete = 'prev' | 'next',
+    
+        -- If set to `last` new buffers are added to the end of the bufferline,
+        -- if `next` they are added next to the current buffer.
+        -- if set to `directory` buffers are sorted by their full path.
+        -- if set to `number` buffers are sorted by bufnr, as in default Neovim
+        -- default: 'last'.
+        ---@type 'last' | 'next' | 'directory' | 'number' | fun(a: Buffer, b: Buffer):boolean
+        new_buffers_position = 'last',
+    
+        -- If true, right clicking a buffer will close it
+        -- The close button will still work normally
+        -- Default: true
+        ---@type boolean
+        delete_on_right_click = true,
+      },
+    
+      mappings = {
+        -- Controls what happens when the first (last) buffer is focused and you
+        -- try to focus/switch the previous (next) buffer. If `true` the last
+        -- (first) buffers gets focused/switched, if `false` nothing happens.
+        -- default: `true`.
+        ---@type boolean
+        cycle_prev_next = true,
+    
+        -- Disables mouse mappings
+        -- default: `false`.
+        ---@type boolean
+        disable_mouse = false,
+      },
+    
+      -- Maintains a history of focused buffers using a ringbuffer
+      history = {
+        ---@type boolean
+        enabled = true,
+        ---The number of buffers to save in the history
+        ---@type integer
+        size = 2
+      },
+    
+      rendering = {
+        -- The maximum number of characters a rendered buffer is allowed to take
+        -- up. The buffer will be truncated if its width is bigger than this
+        -- value.
+        -- default: `999`.
+        ---@type integer
+        max_buffer_width = 999,
+      },
+    
+      pick = {
+        -- Whether to use the filename's first letter first before
+        -- picking a letter from the valid letters list in order.
+        -- default: `true`
+        ---@type boolean
+        use_filename = true,
+    
+        -- The list of letters that are valid as pick letters. Sorted by
+        -- keyboard reachability by default, but may require tweaking for
+        -- non-QWERTY keyboard layouts.
+        -- default: `'asdfjkl;ghnmxcvbziowerutyqpASDFJKLGHNMXCVBZIOWERTYQP'`
+        ---@type string
+        letters = 'asdfjkl;ghnmxcvbziowerutyqpASDFJKLGHNMXCVBZIOWERTYQP',
+      },
+    
+      -- The default highlight group values.
+      -- The `fg`, `bg`, and `sp` keys are either colors in hexadecimal format or
+      -- functions taking a `buffer` parameter and returning a color in
+      -- hexadecimal format. Style attributes work the same way, but functions
+      -- should return boolean values.
+      default_hl = {
+        -- default: `ColorColumn`'s background color for focused buffers,
+        -- `Normal`'s foreground color for unfocused ones.
+        ---@type nil | string | fun(buffer: Buffer): string
+        fg = function(buffer)
+          local hlgroups = require("cokeline.hlgroups")
+          return buffer.is_focused and hlgroups.get_hl_attr("ColorColumn", "bg")
+            or hlgroups.get_hl_attr("Normal", "fg")
+        end,
+    
+        -- default: `Normal`'s foreground color for focused buffers,
+        -- `ColorColumn`'s background color for unfocused ones.
+        -- default: `Normal`'s foreground color.
+        ---@type nil | string | function(buffer: Buffer): string,
+        bg = function(buffer)
+          local hlgroups = require("cokeline.hlgroups")
+          return buffer.is_focused and hlgroups.get_hl_attr("Normal", "fg")
+            or hlgroups.get_hl_attr("ColorColumn", "bg")
+        end,
+    
+        -- default: unset.
+        ---@type nil | string | function(buffer): string,
+        sp = nil,
+    
+        ---@type nil | boolean | fun(buf: Buffer):boolean
+        bold = nil,
+        ---@type nil | boolean | fun(buf: Buffer):boolean
+        italic = nil,
+        ---@type nil | boolean | fun(buf: Buffer):boolean
+        underline = nil,
+        ---@type nil | boolean | fun(buf: Buffer):boolean
+        undercurl = nil,
+        ---@type nil | boolean | fun(buf: Buffer):boolean
+        strikethrough = nil,
+      },
+    
+      -- The highlight group used to fill the tabline space
+      fill_hl = 'TabLineFill',
+    
+      -- A list of components to be rendered for each buffer. Check out the section
+      -- below explaining what this value can be set to.
+      -- default: see `/lua/cokeline/config.lua`
+      ---@type Component[]
+      components = {},
+    
+      -- Custom areas can be displayed on the right hand side of the bufferline.
+      -- They act identically to buffer components, except their methods don't take a Buffer object.
+      -- If you want a rhs component to be stateful, you can wrap it in a closure containing state.
+      ---@type Component[] | false
+      rhs = {},
+    
+      -- Tabpages can be displayed on either the left or right of the bufferline.
+      -- They act the same as other components, except they are passed TabPage objects instead of
+      -- buffer objects.
+      ---@type table | false
+      tabs = {
+        placement = "left" | "right",
+        ---@type Component[]
+        components = {}
+      },
+    
+      -- Left sidebar to integrate nicely with file explorer plugins.
+      -- This is a table containing a `filetype` key and a list of `components` to
+      -- be rendered in the sidebar.
+      -- The last component will be automatically space padded if necessary
+      -- to ensure the sidebar and the window below it have the same width.
+      ---@type table | false
+      sidebar = {
+        ---@type string | string[]
+        filetype = { "NvimTree", "neo-tree", "SidebarNvim" },
+        ---@type Component[]
+        components = {},
+      },
+    })
+<
+
+
+SO WHAT’S FUNCTION(BUFFER)? ~
+
+Some of the configuration options can be functions that take a `Buffer`
+<https://github.com/willothy/nvim-cokeline/wiki/Buffer> as a single parameter.
+This is useful as it allows users to set the values of components dynamically
+based on the buffer that component is being rendered for.
+
+The `Buffer` type is just a Lua table with the following keys:
+
+>lua
+    Buffer = {
+      -- The buffer's order in the bufferline (1 for the first buffer, 2 for the
+      -- second one, etc.).
+      index = int,
+    
+      -- The buffer's internal number as reported by `:ls`.
+      number = int,
+    
+      ---@type boolean
+      is_focused = false,
+    
+      ---@type boolean
+      is_modified = false,
+    
+      ---@type boolean
+      is_readonly = false,
+    
+      -- The buffer is the first visible buffer in the tab bar
+      ---@type boolean
+      is_first    = false,
+    
+      -- The buffer is the last visible buffer in the tab bar
+      ---@type boolean
+      is_last     = false,
+    
+      -- The mouse is hovering over the current component in the buffer
+      -- This is a special variable in that it will only be true for the hovered *component*
+      -- on render. This is to allow components to respond to hover events individually without managing
+      -- component state.
+      ---@type boolean
+      is_hovered  = false,
+    
+      -- The mouse is hovering over the buffer (true for all components)
+      ---@type boolean
+      buf_hovered = false,
+    
+      -- The buffer's type as reported by `:echo &buftype`.
+      ---@type string
+      ---@type string
+      type = '',
+    
+      -- The buffer's filetype as reported by `:echo &filetype`.
+      ---@type string
+      filetype = '',
+    
+      -- The buffer's full path.
+      ---@type string
+      path = '',
+    
+      -- The buffer's filename.
+      ---@type string
+      filename = 'string',
+    
+      -- A unique prefix used to distinguish buffers with the same filename
+      -- stored in different directories. For example, if we have two files
+      -- `bar/foo.md` and `baz/foo.md`, then the first will have `bar/` as its
+      -- unique prefix and the second one will have `baz/`.
+      ---@type string
+      unique_prefix = '',
+    
+      -- The letter that is displayed when picking a buffer to either focus or
+      -- close it.
+      ---@type string
+      pick_letter = 'char',
+    
+      -- This needs the `nvim-tree/nvim-web-devicons` plugin to be installed.
+      devicon = {
+        -- An icon representing the buffer's filetype.
+        ---@type string
+        icon = 'string',
+    
+        -- The colors of the devicon in hexadecimal format (useful to be passed
+        -- to a component's `fg` field (see the `Components` section).
+        color = '#rrggbb',
+      },
+    
+      -- The values in this table are the ones reported by Neovim's built in
+      -- LSP interface.
+      diagnostics = {
+        ---@type integer
+        errors = 0,
+        ---@type integer
+        warnings = 0,
+        ---@type integer
+        infos = 0,
+        ---@type integer
+        hints = 0,
+      },
+    }
+<
+
+It also has methods that can be used in component event handlers:
+
+>lua
+    ---@param self Buffer
+    ---Deletes the buffer
+    function Buffer:delete() end
+    
+    ---@param self Buffer
+    ---Focuses the buffer
+    function Buffer:focus() end
+    
+    ---@param self Buffer
+    ---@return number
+    ---Returns the number of lines in the buffer
+    function Buffer:lines() end
+    
+    ---@param self Buffer
+    ---@return string[]
+    ---Returns the buffer's lines
+    function Buffer:text() end
+    
+    ---@param buf Buffer
+    ---@return boolean
+    ---Returns true if the buffer is valid
+    function Buffer:is_valid() end
+<
+
+
+WHAT ABOUT TABPAGES? ~
+
+Each method on a tab component is passed a `TabPage` object as an argument.
+
+`TabPage`, like `Buffer`, is simply a Lua table with some relevant data
+attached.
+
+>lua
+    TabPage = {
+      -- The tabpage number, as reported by `nvim_list_tabpages`
+      ---@type integer
+      number = 0,
+      -- A list of Window objects contained in the TabPage (see wiki for more info)
+      ---@type Window[]
+      windows = {},
+      -- The currently focused window in the TabPage
+      ---@type Window
+      focused = nil,
+      -- True if the TabPage is the current TabPage
+      ---@type boolean
+      is_active = true,
+      -- True if the TabPage is first in the list
+      ---@type boolean
+      is_first = false,
+      -- True if the TabPage is last in the list
+      ---@type boolean
+      is_last = false
+    }
+<
+
+
+AND COMPONENTS? ~
+
+You can configure what each buffer in your bufferline will be composed of by
+passing a list of components to the `setup` function.
+
+For example, let’s imagine we want to construct a very minimal bufferline
+where the only things we’re displaying for each buffer are its index, its
+filename and a close button.
+
+Then in our `setup` function we’d have:
+
+>lua
+    require('cokeline').setup({
+      -- ...
+      components = {
+        {
+          text = function(buffer) return ' ' .. buffer.index end,
+        },
+        {
+          text = function(buffer) return ' ' .. buffer.filename .. ' ' end,
+        },
+        {
+          text = '󰅖',
+          on_click = function(_, _, _, _, buffer)
+            buffer:delete()
+          end
+        },
+        {
+          text = ' ',
+        }
+      }
+    })
+<
+
+in this case every buffer would be composed of four components: the first
+displaying a space followed by the buffer index, the second one the filename
+padded by a space on each side, then a close button that allows us to
+`:bdelete` the buffer by left-clicking on it, and finally an extra space.
+
+This way of dividing each buffer into distinct components, combined with the
+ability to define every component’s text and color depending on some property
+of the buffer we’re rendering, allows for great customizability.
+
+Every component passed to the `components` list has to be a table of the form:
+
+>lua
+    {
+    
+      ---@type string | fun(buffer: Buffer): string
+      text = "",
+    
+      -- The foreground, backgrond and style of the component
+      ---@type nil | string | fun(buffer: Buffer): string
+      fg = '#rrggbb',
+      ---@type nil | string | fun(buffer: Buffer): string
+      bg = '#rrggbb',
+      ---@type nil | string | fun(buffer: Buffer): string
+      sp = '#rrggbb',
+      ---@type nil | boolean | fun(buffer: Buffer): boolean
+      bold = false,
+      ---@type nil | boolean | fun(buffer: Buffer): boolean
+      italic = false,
+      ---@type nil | boolean | fun(buffer: Buffer): boolean
+      underline = false,
+      ---@type nil | boolean | fun(buffer: Buffer): boolean
+      undercurl = false,
+      ---@type nil | boolean | fun(buffer: Buffer): boolean
+      strikethrough = false,
+    
+      -- Or, alternatively, the name of the highlight group
+      ---@type nil | string | fun(buffer: Buffer): string
+      highlight = nil,
+    
+      -- If `true` the buffer will be deleted when this component is
+      -- left-clicked (usually used to implement close buttons, overrides `on_click`).
+      -- deprecated, it is recommended to use the Buffer:delete() method in an on_click event
+      -- to implement close buttons instead.
+      ---@type boolean
+      delete_buffer_on_left_click = false,
+    
+      -- Handles click event for a component
+      -- If not set, component will have the default click behavior
+      -- buffer is a Buffer object, not a bufnr
+      ---@type nil | fun(idx: integer, clicks: integer, button: string, mods: string, buffer: Buffer)
+      on_click = nil,
+    
+      -- Called on a component when hovered
+      ---@type nil | function(buffer: Buffer, mouse_col: integer)
+      on_mouse_enter = nil,
+    
+      -- Called on a component when unhovered
+      ---@type nil | function(buffer: Buffer, mouse_col: integer)
+      on_mouse_leave = nil,
+    
+      truncation = {
+        -- default: index of the component in the `components` table (1 for the
+        -- first component, 2 for the second, etc.).
+        ---@type integer
+        priority = 1,
+    
+        -- default: `right`.
+        ---@type 'left' | 'middle' | 'right'
+        direction = 'left' | 'middle' | 'right',
+      },
+    }
+<
+
+the `text` key is the only one that has to be set, all the others are optional
+and can be omitted.
+
+The `truncation` table controls what happens when a buffer is too long to be
+displayed in its entirety.
+
+More specifically, if a buffer’s width (given by the sum of the widths of all
+its components) is bigger than the `rendering.max_buffer_width` config option,
+the buffer will be truncated.
+
+The default behaviour is truncate the buffer by dropping components from right
+to left, with the text of the last component that’s included also being
+shortened from right to left. This can be modified by changing the values of
+the `truncation.priority` and `truncation.direction` keys.
+
+The `truncation.priority` controls the order in which components are dropped:
+the first component to be dropped will be the one with the lowest priority. If
+that’s still not enough to bring the width of the buffer within the
+`rendering.max_buffer_width` limit, the component with the second lowest
+priority will be dropped, and so on. Note that a higher priority means a
+smaller integer value: a component with a priority of 5 will be dropped _after_
+a component with a priority of 6, even though 6 > 5.
+
+The `truncation.direction` key simply controls from which direction a component
+is shortened. For example, you might want to set the `truncation.direction` of
+a component displaying a filename to `'middle'` or `'left'`, so that if the
+filename has to be shortened you’ll still be able to see its extension, like
+in the following example (where it’s set to `'left'`):
+
+
+WHAT ABOUT HISTORY?
+
+The History keeps track of the buffers you access using a ringbuffer, and
+provides an API for accessing Buffer objects from the history.
+
+You can access the history using `require("cokeline.history")`, or through the
+global `_G.cokeline.history`.
+
+The `History` object provides these methods:
+
+>lua
+    History = {}
+    
+    ---Adds a Buffer object to the history
+    ---@type bufnr integer
+    function History:push(bufnr)
+    end
+    
+    ---Removes and returns the oldest Buffer object in the history
+    ---@return Buffer?
+    function History:pop()
+    end
+    
+    ---Returns a list of Buffer objects in the history,
+    ---ordered from oldest to newest
+    ---@return Buffer[]
+    function History:list()
+    end
+    
+    ---Returns an iterator of Buffer objects in the history,
+    ---ordered from oldest to newest
+    ---@return fun(): Buffer?
+    function History:iter()
+    end
+    
+    ---Get a Buffer object by history index
+    ---@param idx integer
+    ---@return Buffer?
+    function History:get(idx)
+    end
+    
+    ---Get a Buffer object representing the last-accessed buffer (before the current one)
+    ---@return Buffer?
+    function History:last()
+    end
+    
+    ---Returns true if the history is empty
+    ---@return boolean
+    function History:is_empty()
+    end
+    
+    ---Returns the maximum number of buffers that can be stored in the history
+    ---@return integer
+    function History:capacity()
+    end
+    
+    ---Returns true if the history contains the given buffer
+    ---@param bufnr integer
+    ---@return boolean
+    function History:contains(bufnr)
+    end
+    
+    ---Returns the number of buffers in the history
+    ---@return integer
+    function History:len()
+    end
+<
+
+
+MAPPINGS                                                   *cokeline-mappings*
+
+You can use the `mappings` module to create mappings from Lua:
+
+>lua
+    vim.keymap.set("n", "<leader>bp", function()
+        require('cokeline.mappings').pick("focus")
+    end, { desc = "Pick a buffer to focus" })
+<
+
+Alternatively, we expose the following `<Plug>` mappings which can be used as
+the right hand side of other mappings:
+
+>
+    -- Focus the previous/next buffer
+    <Plug>(cokeline-focus-prev)
+    <Plug>(cokeline-focus-next)
+    
+    -- Switch the position of the current buffer with the previous/next buffer.
+    <Plug>(cokeline-switch-prev)
+    <Plug>(cokeline-switch-next)
+    
+    -- Focuses the buffer with index `i`.
+    <Plug>(cokeline-focus-i)
+    
+    -- Switches the position of the current buffer with the buffer of index `i`.
+    <Plug>(cokeline-switch-i)
+    
+    -- Focus a buffer by its `pick_letter`.
+    <Plug>(cokeline-pick-focus)
+    
+    -- Close a buffer by its `pick_letter`.
+    <Plug>(cokeline-pick-close)
+<
+
+A possible configuration could be:
+
+>lua
+    local map = vim.api.nvim_set_keymap
+    
+    map("n", "<S-Tab>", "<Plug>(cokeline-focus-prev)", { silent = true })
+    map("n", "<Tab>", "<Plug>(cokeline-focus-next)", { silent = true })
+    map("n", "<Leader>p", "<Plug>(cokeline-switch-prev)", { silent = true })
+    map("n", "<Leader>n", "<Plug>(cokeline-switch-next)", { silent = true })
+    
+    for i = 1, 9 do
+      map(
+        "n",
+        ("<F%s>"):format(i),
+        ("<Plug>(cokeline-focus-%s)"):format(i),
+        { silent = true }
+      )
+      map(
+        "n",
+        ("<Leader>%s"):format(i),
+        ("<Plug>(cokeline-switch-%s)"):format(i),
+        { silent = true }
+      )
+    end
+<
+
+Generated by panvimdoc <https://github.com/kdheepak/panvimdoc>
+
+vim:tw=78:ts=8:noet:ft=help:norl:

--- a/lua/plugins/nvim-cokeline/CODES/lua/cokeline/augroups.lua
+++ b/lua/plugins/nvim-cokeline/CODES/lua/cokeline/augroups.lua
@@ -1,0 +1,146 @@
+local lazy = require("cokeline.lazy")
+local state = lazy("cokeline.state")
+local buffers = lazy("cokeline.buffers")
+local tabs = lazy("cokeline.tabs")
+local config = lazy("cokeline.config")
+
+local cmd = vim.cmd
+local filter = vim.tbl_filter
+local fn = vim.fn
+local opt = vim.opt
+
+local toggle = function()
+  local listed_buffers = fn.getbufinfo({ buflisted = 1 })
+  opt.showtabline = #listed_buffers > 0 and 2 or 0
+end
+
+local bufnr_to_close
+
+local close_bufnr = function()
+  if bufnr_to_close then
+    cmd("b" .. bufnr_to_close)
+    bufnr_to_close = nil
+  end
+end
+
+---@param bufnr  number
+local remember_bufnr = function(bufnr)
+  if #state.valid_buffers == 1 then
+    return
+  end
+
+  local deleted_buffer = filter(function(buffer)
+    return buffer.number == bufnr
+  end, state.valid_buffers)[1]
+
+  -- Neogit buffers do some weird stuff like closing themselves on buffer
+  -- change and seem to cause problems. We just ignore them.
+  -- See https://github.com/noib3/nvim-cokeline/issues/43
+  if
+    not deleted_buffer or deleted_buffer.filename:find("Neogit", nil, true)
+  then
+    return
+  end
+
+  local target_index
+
+  if config.buffers.focus_on_delete == "prev" then
+    target_index = deleted_buffer._valid_index ~= 1
+        and deleted_buffer._valid_index - 1
+      or 2
+  elseif config.buffers.focus_on_delete == "next" then
+    target_index = deleted_buffer._valid_index ~= #state.valid_buffers
+        and deleted_buffer._valid_index + 1
+      or #state.valid_buffers - 1
+  end
+
+  bufnr_to_close = state.valid_buffers[target_index].number
+end
+
+local setup = function()
+  local autocmd, augroup =
+    vim.api.nvim_create_autocmd, vim.api.nvim_create_augroup
+
+  local group = augroup("cokeline_autocmds", { clear = true })
+
+  -- Invalidate the cache on colorscheme change
+  autocmd("ColorScheme", {
+    group = group,
+    callback = function()
+      require("cokeline.hlgroups")._cache_clear()
+    end,
+  })
+
+  autocmd({ "VimEnter", "BufAdd" }, {
+    group = group,
+    callback = function()
+      require("cokeline.augroups").toggle()
+    end,
+  })
+  autocmd({ "BufDelete", "BufWipeout" }, {
+    group = group,
+    callback = function(args)
+      require("cokeline.buffers").release_taken_letter(args.buf)
+    end,
+  })
+  if config.history.enabled then
+    autocmd("BufLeave", {
+      group = group,
+      callback = function(args)
+        if vim.api.nvim_buf_is_valid(args.buf) then
+          require("cokeline.history"):push(args.buf)
+        end
+      end,
+    })
+  end
+  if config.tabs then
+    autocmd({ "TabNew", "TabClosed" }, {
+      group = group,
+      callback = function()
+        tabs.fetch_tabs()
+      end,
+    })
+    autocmd("WinEnter", {
+      group = group,
+      callback = function()
+        local win = vim.api.nvim_get_current_win()
+        local tab = vim.api.nvim_win_get_tabpage(win)
+        if not state.tab_lookup[tab] then
+          tabs.fetch_tabs()
+          return
+        end
+        tabs.update_current(tab)
+        for _, w in ipairs(state.tab_lookup[tab].windows) do
+          if w.number == win then
+            state.tab_lookup[tab].focused = w
+            break
+          end
+        end
+      end,
+    })
+    autocmd("BufEnter", {
+      group = group,
+      callback = function(args)
+        local win = vim.api.nvim_get_current_win()
+        local tab = vim.api.nvim_win_get_tabpage(win)
+        if not state.tab_lookup[tab] then
+          tabs.fetch_tabs()
+          return
+        end
+        for _, w in ipairs(state.tab_lookup[tab].windows) do
+          if w.number == win then
+            w.buffer = buffers.get_buffer(args.buf)
+            break
+          end
+        end
+      end,
+    })
+  end
+end
+
+return {
+  close_bufnr = close_bufnr,
+  remember_bufnr = remember_bufnr,
+  setup = setup,
+  toggle = toggle,
+}

--- a/lua/plugins/nvim-cokeline/CODES/lua/cokeline/buffers.lua
+++ b/lua/plugins/nvim-cokeline/CODES/lua/cokeline/buffers.lua
@@ -1,0 +1,537 @@
+local lazy = require("cokeline.lazy")
+local config = lazy("cokeline.config")
+local state = lazy("cokeline.state")
+
+local has_devicons, rq_devicons = pcall(require, "nvim-web-devicons")
+
+local concat = table.concat
+local sort = table.sort
+
+local bo = vim.bo
+local cmd = vim.cmd
+local diagnostic = vim.diagnostic or vim.lsp.diagnostic
+local fn = vim.fn
+local split = vim.split
+
+local util = lazy("cokeline.utils")
+local iter = vim.iter
+
+---@type bufnr
+local current_valid_index
+
+---@type string?
+local valid_pick_letters
+
+local taken_pick_letters = {}
+local taken_pick_indices = {}
+local buf_order = {}
+
+local M = {}
+
+---@alias valid_index  number
+---@alias index  number
+---@alias bufnr  number
+
+---@class Buffer
+---@field _valid_index  valid_index
+---@field index         index
+---@field number        bufnr
+---@field type          string
+---@field is_focused    boolean
+---@field is_modified   boolean
+---@field is_readonly   boolean
+---@field is_hovered    boolean Whether the current component is hovered
+---@field buf_hovered   boolean Whether any component in the buffer is hovered
+---@field path          string
+---@field unique_prefix string
+---@field filename      string
+---@field filetype      string
+---@field pick_letter   string
+---@field devicon       table<string, string>
+---@field diagnostics   table<string, number>
+local Buffer = {}
+Buffer.__index = Buffer
+
+---@param buffers  Iterator|table
+---@return Iterator|table
+local compute_unique_prefixes = function(buffers)
+  local is_windows = fn.has("win32") == 1
+
+  local path_separator = not is_windows and "/" or "\\"
+
+  local prefixes = {}
+  local paths = {}
+  buffers = buffers
+    :map(function(buffer)
+      prefixes[#prefixes + 1] = {}
+      paths[#paths + 1] = fn.reverse(
+        split(
+          is_windows and buffer.path:gsub("/", "\\") or buffer.path,
+          path_separator
+        )
+      )
+      return buffer
+    end)
+    :totable()
+
+  for i = 1, #paths do
+    for j = i + 1, #paths do
+      local k = 1
+      while paths[i][k] == paths[j][k] and paths[i][k] do
+        k = k + 1
+        prefixes[i][k - 1] = prefixes[i][k - 1] or paths[i][k]
+        prefixes[j][k - 1] = prefixes[j][k - 1] or paths[j][k]
+      end
+      if k ~= 1 then
+        prefixes[i][k - 1] = prefixes[i][k - 1] or paths[i][k]
+        prefixes[j][k - 1] = prefixes[j][k - 1] or paths[j][k]
+      end
+    end
+  end
+
+  return iter(buffers):enumerate():map(function(i, buffer)
+    buffer.unique_prefix = concat({
+      #prefixes[i] == #paths[i] and path_separator or "",
+      ---@diagnostic disable-next-line: param-type-mismatch
+      fn.join(fn.reverse(prefixes[i]), path_separator),
+      #prefixes[i] > 0 and path_separator or "",
+    })
+    return i, buffer
+  end)
+end
+
+---@param filename  string
+---@param bufnr  bufnr
+---@return string
+local get_pick_letter = function(filename, bufnr)
+  local first_valid = 1
+
+  -- Initialize the valid letters string, if not already initialized
+  if not valid_pick_letters then
+    valid_pick_letters = config.pick.letters
+  end
+
+  -- If the bufnr has already a letter associated to it return that.
+  if taken_pick_letters[bufnr] then
+    return taken_pick_letters[bufnr]
+  end
+
+  -- If the config option pick.use_filename is true, and the initial letter
+  -- of the filename is valid and it hasn't already been assigned return that.
+  if config.pick.use_filename and filename ~= "" then
+    local init_letter = vim.fn.strcharpart(filename, 0, 1) or ""
+    local idx = valid_pick_letters:find(init_letter, nil, true)
+
+    if idx == nil or taken_pick_indices[idx] then
+      while
+        taken_pick_indices[first_valid]
+        and first_valid <= vim.fn.strcharlen(valid_pick_letters)
+      do
+        first_valid = first_valid + 1
+      end
+      idx = first_valid
+    end
+    if idx then
+      local letter = vim.fn.strcharpart(valid_pick_letters, idx - 1, 1)
+      if letter and letter ~= "" then
+        taken_pick_letters[bufnr] = letter
+        taken_pick_indices[idx] = true
+
+        return letter
+      end
+    end
+  end
+
+  -- Return the first valid letter if there is one.
+  while
+    taken_pick_indices[first_valid]
+    and first_valid <= vim.fn.strcharlen(valid_pick_letters)
+  do
+    first_valid = first_valid + 1
+  end
+  if first_valid <= vim.fn.strcharlen(valid_pick_letters) then
+    local letter = vim.fn.strcharpart(valid_pick_letters, first_valid - 1, 1)
+    taken_pick_letters[bufnr] = letter
+    taken_pick_indices[first_valid] = true
+    return letter
+  end
+
+  -- Finally, just return a '?' (this is rarely reached, you'd need to have
+  -- opened 54 buffers in the same session).
+  return "?"
+end
+
+---@param path  string
+---@param filename  string
+---@param buftype  string
+---@param filetype  string
+---@return table<string, string>
+local get_devicon = function(path, filename, buftype, filetype)
+  local name = (buftype == "terminal") and "terminal" or filename
+
+  local extn = fn.fnamemodify(path, ":e")
+  local icon, color =
+    rq_devicons.get_icon_color(name, extn, { default = false })
+  if not icon then
+    icon, color =
+      rq_devicons.get_icon_color_by_filetype(filetype, { default = true })
+  end
+
+  return {
+    icon = icon .. " ",
+    color = color,
+  }
+end
+
+---@param bufnr  bufnr
+---@return table<string, number>
+local get_diagnostics = function(bufnr)
+  local diagnostics = {
+    errors = 0,
+    warnings = 0,
+    infos = 0,
+    hints = 0,
+  }
+
+  for _, d in ipairs(diagnostic.get(bufnr)) do
+    if d.severity == 1 then
+      diagnostics.errors = diagnostics.errors + 1
+    elseif d.severity == 2 then
+      diagnostics.warnings = diagnostics.warnings + 1
+    elseif d.severity == 3 then
+      diagnostics.infos = diagnostics.infos + 1
+    elseif d.severity == 4 then
+      diagnostics.hints = diagnostics.hints + 1
+    end
+  end
+
+  return diagnostics
+end
+
+---@param b  table
+---@return Buffer
+Buffer.new = function(b)
+  local opts = bo[b.bufnr]
+
+  local number = b.bufnr
+  local buftype = opts.buftype
+  local path = b.name
+
+  local filename = (type == "quickfix" and "quickfix")
+    or (#path > 0 and fn.fnamemodify(path, ":t"))
+  ---@cast filename string
+
+  local filetype = not (b.variables and b.variables.netrw_browser_active)
+      and opts.filetype
+    or "netrw"
+
+  local pick_letter = get_pick_letter(filename or "", number)
+
+  local devicon = has_devicons
+      and get_devicon(path, filename, buftype, filetype)
+    or { icon = "", color = "" }
+
+  return setmetatable({
+    _valid_index = buf_order[b.bufnr] or -1,
+    index = -1,
+    number = b.bufnr,
+    type = opts.buftype,
+    is_focused = (b.bufnr == vim.api.nvim_get_current_buf()),
+    is_first = false,
+    is_last = false,
+    is_modified = opts.modified,
+    is_readonly = opts.readonly,
+    is_hovered = false,
+    buf_hovered = false,
+    path = b.name,
+    unique_prefix = "",
+    filename = filename or "[No Name]",
+    filetype = filetype,
+    pick_letter = pick_letter,
+    devicon = devicon,
+    diagnostics = get_diagnostics(number),
+  }, Buffer)
+end
+
+---@param self Buffer
+---Deletes the buffer
+function Buffer:delete()
+  util.buf_delete(self.number)
+  vim.cmd.redrawtabline()
+end
+
+---@param self Buffer
+---Focuses the buffer
+function Buffer:focus()
+  vim.api.nvim_set_current_buf(self.number)
+end
+
+---@param self Buffer
+---@return number
+---Returns the number of lines in the buffer
+function Buffer:lines()
+  return vim.api.nvim_buf_line_count(self.number)
+end
+
+---@param self Buffer
+---@return string[]
+---Returns the buffer's lines
+function Buffer:text()
+  return vim.api.nvim_buf_get_lines(self.number, 0, -1, false)
+end
+
+---@return boolean
+---Returns true if the buffer is valid
+function Buffer:is_valid()
+  return vim.api.nvim_buf_is_valid(self.number)
+end
+
+---@param buffer  Buffer
+---@return boolean
+local is_old = function(buffer)
+  for _, buf in pairs(state.valid_buffers) do
+    if buffer.number == buf.number then
+      return true
+    end
+  end
+  return false
+end
+
+---@param buffer  Buffer
+---@return boolean
+local is_new = function(buffer)
+  return not is_old(buffer)
+end
+
+---Sorter used to open new buffers at the end of the bufferline.
+---@param buffer1  Buffer
+---@param buffer2  Buffer
+---@return boolean
+local sort_by_new_after_last = function(buffer1, buffer2)
+  if is_old(buffer1) and is_old(buffer2) then
+    return buffer1._valid_index < buffer2._valid_index
+  elseif is_old(buffer1) and is_new(buffer2) then
+    return true
+  elseif is_new(buffer1) and is_old(buffer2) then
+    return false
+  else
+    return buffer1.number < buffer2.number
+  end
+end
+
+---Sorter used to open new buffers next to the current buffer.
+---@param buffer1  Buffer
+---@param buffer2  Buffer
+---@return boolean
+local sort_by_new_after_current = function(buffer1, buffer2)
+  if is_old(buffer1) and is_old(buffer2) then
+    -- If both buffers are either before or after (inclusive) the current
+    -- buffer, respect the current order.
+    if
+      (buffer1._valid_index - current_valid_index)
+        * (buffer2._valid_index - current_valid_index)
+      >= 0
+    then
+      return buffer1._valid_index < buffer2._valid_index
+    end
+    return buffer1._valid_index < current_valid_index
+  elseif is_old(buffer1) and is_new(buffer2) then
+    return buffer1._valid_index <= current_valid_index
+  elseif is_new(buffer1) and is_old(buffer2) then
+    return current_valid_index < buffer2._valid_index
+  else
+    return buffer1.number < buffer2.number
+  end
+end
+
+---Sorter used to order buffers by full path.
+---@param buffer1  Buffer
+---@param buffer2  Buffer
+---@return boolean
+local sort_by_directory = function(buffer1, buffer2)
+  return buffer1.path < buffer2.path
+end
+
+---Sorted used to order buffers by number, as in the default tabline.
+---@param buffer1  Buffer
+---@param buffer2  Buffer
+---@return boolean
+local sort_by_number = function(buffer1, buffer2)
+  return buffer1.number < buffer2.number
+end
+
+---@param bufnr  bufnr
+---@return nil
+function M.release_taken_letter(bufnr)
+  if taken_pick_letters[bufnr] then
+    local idx = (valid_pick_letters or ""):find(taken_pick_letters[bufnr])
+    if idx then
+      taken_pick_indices[idx] = nil
+      taken_pick_letters[bufnr] = nil
+    end
+  end
+end
+
+---@param buffer  Buffer
+---@param target_valid_index  valid_index
+function M.move_buffer(buffer, target_valid_index)
+  if buffer._valid_index == target_valid_index then
+    return
+  end
+
+  buf_order[buffer.number] = target_valid_index
+
+  if buffer._valid_index < target_valid_index then
+    for index = (buffer._valid_index + 1), target_valid_index do
+      buf_order[state.valid_buffers[index].number] = index - 1
+    end
+  else
+    for index = target_valid_index, (buffer._valid_index - 1) do
+      buf_order[state.valid_buffers[index].number] = index + 1
+    end
+  end
+
+  cmd("redrawtabline")
+end
+
+---@return Buffer[]
+function M.get_valid_buffers()
+  if not buf_order then
+    buf_order = {}
+  end
+
+  local info = fn.getbufinfo({ buflisted = 1 })
+  ---@type Iterator|table
+  local buffers = iter(info):map(Buffer.new):filter(function(buffer)
+    return buffer.filetype ~= "netrw"
+  end)
+
+  if config.buffers.filter_valid then
+    ---@type Iterator|table
+    buffers = buffers:filter(config.buffers.filter_valid)
+  end
+
+  ---@type Iterator|table
+  buffers = compute_unique_prefixes(buffers)
+
+  if current_valid_index == nil then
+    buf_order = {}
+    buffers = buffers
+      :map(function(i, buffer)
+        buffer._valid_index = i
+        buf_order[buffer.number] = buffer._valid_index
+        if buffer.is_focused then
+          current_valid_index = i
+        end
+        return buffer
+      end)
+      :totable()
+  else
+    buffers = buffers
+      :map(function(_, buf)
+        return buf
+      end)
+      :totable()
+  end
+  if not current_valid_index then
+    current_valid_index = 0
+  end
+
+  if type(config.buffers.new_buffers_position) == "function" then
+    sort(buffers, config.buffers.new_buffers_position)
+  elseif config.buffers.new_buffers_position == "last" then
+    sort(buffers, sort_by_new_after_last)
+  elseif config.buffers.new_buffers_position == "next" then
+    sort(buffers, sort_by_new_after_current)
+  elseif config.buffers.new_buffers_position == "directory" then
+    sort(buffers, sort_by_directory)
+  elseif config.buffers.new_buffers_position == "number" then
+    sort(buffers, sort_by_number)
+  end
+
+  buf_order = {}
+  for i, buffer in ipairs(buffers) do
+    buffer._valid_index = i
+    buf_order[buffer.number] = buffer._valid_index
+    if buffer.is_focused then
+      current_valid_index = i
+    end
+  end
+
+  return buffers
+end
+
+---@return Buffer[]
+function M.get_visible()
+  state.valid_buffers = M.get_valid_buffers()
+  state.valid_lookup = {}
+
+  local bufs = iter(state.valid_buffers):map(function(buffer)
+    state.valid_lookup[buffer.number] = buffer
+    return buffer
+  end)
+
+  if config.buffers.filter_visible then
+    bufs = bufs:filter(config.buffers.filter_visible)
+  end
+
+  bufs = bufs:enumerate():map(function(i, buf)
+    buf.index = i
+    return buf
+  end)
+
+  if not config.pick.use_filename then
+    bufs = bufs:map(function(buf)
+      buf.pick_letter = get_pick_letter(buf.filename, buf.number)
+      return buf
+    end)
+  end
+
+  state.visible_buffers = bufs:totable()
+
+  if #state.visible_buffers > 0 then
+    state.visible_buffers[1].is_first = true
+    state.visible_buffers[#state.visible_buffers].is_last = true
+  end
+
+  return state.visible_buffers
+end
+
+---Get Buffer
+---@param bufnr number
+---@return Buffer|nil
+function M.get_buffer(bufnr)
+  return require("cokeline.state").valid_lookup[bufnr]
+end
+
+---Wrapper around `vim.api.nvim_get_current_buf`, returns Buffer object
+---@return Buffer|nil
+function M.get_current()
+  local bufnr = vim.api.nvim_get_current_buf()
+  if bufnr then
+    return M.get_buffer(bufnr)
+  end
+end
+
+---@param bufnr bufnr
+---@return boolean
+function M.is_visible(bufnr)
+  local buf = M.get_buffer(bufnr)
+  if not buf then
+    return false
+  end
+  if config.buf.filter_valid and not config.buffers.filter_valid(buf) then
+    return false
+  end
+  if
+    config.buffers.filter_visible
+    and not config.buffers.filter_visible(buf)
+  then
+    return false
+  end
+  return true
+end
+
+M.Buffer = Buffer
+
+return M

--- a/lua/plugins/nvim-cokeline/CODES/lua/cokeline/components.lua
+++ b/lua/plugins/nvim-cokeline/CODES/lua/cokeline/components.lua
@@ -1,0 +1,297 @@
+local lazy = require("cokeline.lazy")
+local Hlgroup = require("cokeline.hlgroups").Hlgroup
+local config = lazy("cokeline.config")
+
+local rep = string.rep
+local insert = table.insert
+local remove = table.remove
+
+local iter = vim.iter
+local fn = vim.fn
+
+---@generic Cx
+---@class Component<Cx>
+---@field index  number
+---@field text  string|fun(cx: Cx): string
+---@field style  string|fun(cx: Cx): string
+---@field fg  string|fun(cx: Cx): string
+---@field bg  string|fun(cx: Cx): string
+---@field highlight  string|fun(cx: Cx): string
+---@field on_click ClickHandler<Cx> | nil
+---@field on_mouse_enter MouseEnterHandler<Cx> | nil
+---@field on_mouse_leave MouseLeaveHandler<Cx> | nil
+---@field delete_buffer_on_left_click  boolean Use the component as a close button ()
+---@field truncation  table
+---@field idx  number
+---@field bufnr  bufnr
+---@field width  number
+---@field hlgroup  Hlgroup
+local Component = {}
+Component.__index = Component
+
+---@generic Cx
+---@param c table | Component<Cx>
+---@param i number
+---@return Component<Cx>
+Component.new = function(c, i, default_hl)
+  local function attr(name, default)
+    if c[name] ~= nil then
+      return c[name]
+    end
+    if default_hl[name] ~= nil then
+      return default_hl[name]
+    end
+    return default
+  end
+  -- `default_hl` is `nil` when called by `components.lua#63`
+  default_hl = default_hl or config.default_hl
+  local component = {
+    index = i,
+    text = c.text,
+    fg = attr("fg", "NONE"),
+    bg = attr("bg", "NONE"),
+    sp = attr("sp", "NONE"),
+    bold = attr("bold"),
+    italic = attr("italic"),
+    underline = attr("underline"),
+    undercurl = attr("undercurl"),
+    strikethrough = attr("strikethrough"),
+    highlight = c.highlight,
+    delete_buffer_on_left_click = c.delete_buffer_on_left_click or false,
+    on_click = c.on_click,
+    on_mouse_enter = c.on_mouse_enter,
+    on_mouse_leave = c.on_mouse_leave,
+    truncation = {
+      priority = c.truncation and c.truncation.priority or i,
+      direction = c.truncation and c.truncation.direction or "right",
+    },
+    -- These values aren't ready yet, they will be once the component gets
+    -- rendered for a specific buffer.
+    width = nil,
+    bufnr = nil,
+    hlgroup = nil,
+    kind = c.kind or "buffer",
+  }
+  setmetatable(component, Component)
+  return component
+end
+
+-- Renders a component for a specific buffer.
+---@generic Cx
+---@param self   Component<Cx>
+---@param context RenderContext
+---@return Component
+Component.render = function(self, context)
+  ---@return string
+  local evaluate = function(field)
+    if field == nil then
+      return
+    end
+    if type(field) == "function" then
+      return field(context.provider)
+    end
+    return field
+  end
+
+  local component = vim.deepcopy(self)
+  component.text = evaluate(self.text)
+  component.width = fn.strwidth(component.text)
+
+  if
+    context.kind == "buffer"
+    or context.kind == "sidebar"
+    or context.kind == "tab"
+  then
+    component.bufnr = context.provider.number
+  end
+
+  if component.highlight then
+    component.hlgroup = Hlgroup.new_existing(evaluate(component.highlight))
+  else
+    -- `evaluate(self.hl.*)` might return `nil`, in that case we fallback to the
+    -- default highlight first and to NONE if that's `nil` too.
+    -- local style = evaluate(self.style)
+    --   or evaluate(config.default_hl.style)
+    --   or "NONE"
+    local fg = evaluate(self.fg) or evaluate(config.default_hl.fg) or "NONE"
+    local bg = evaluate(self.bg) or evaluate(config.default_hl.bg) or "NONE"
+    local sp = evaluate(self.sp) or evaluate(config.default_hl.sp) or "NONE"
+    local attrs = {}
+    attrs.bold = evaluate(self.bold) or evaluate(config.default_hl.bold)
+    attrs.italic = evaluate(self.italic) or evaluate(config.default_hl.italic)
+    attrs.underline = evaluate(self.underline)
+      or evaluate(config.default_hl.underline)
+    attrs.undercurl = evaluate(self.undercurl)
+      or evaluate(config.default_hl.undercurl)
+    attrs.strikethrough = evaluate(self.strikethrough)
+      or evaluate(config.default_hl.strikethrough)
+
+    component.hlgroup = Hlgroup.new(
+      ("Cokeline_%s_%s"):format(component.bufnr or context.kind, self.index),
+      fg,
+      bg,
+      sp,
+      attrs
+    )
+  end
+
+  return component
+end
+
+---@generic Cx
+---@param self      Component<Cx>
+---@param to_width  number
+---@param direction '"left"' | '"right"' | nil
+Component.shorten = function(self, to_width, direction)
+  -- If a direction is given that means we're cutting off a component that's
+  -- at the edge of the bufferline (either the left or the right one). In this
+  -- case we either prepend or append a space to the ellipses.
+  --
+  -- If a direction isn't given we're shortening a component within a buffer.
+  -- Here we use that component's `truncation.direction`, and we don't add any
+  -- additional spaces.
+  if direction then
+    local available_width = to_width - 2
+    local start = direction == "left" and self.width - available_width or 0
+    self.text = (direction == "left" and " …%s" or "%s… "):format(
+      fn.strcharpart(self.text, start, available_width)
+    )
+  elseif self.truncation.direction == "middle" then
+    local available_width = to_width - 1
+    local width_left = math.floor(available_width / 2)
+    local width_right = width_left + available_width % 2
+    self.text = ("%s…%s"):format(
+      fn.strcharpart(self.text, 0, width_left),
+      fn.strcharpart(self.text, self.width - width_right, width_right)
+    )
+  else
+    direction = self.truncation.direction
+    local available_width = to_width - 1
+    local start = direction == "left" and self.width - available_width or 0
+    self.text = (direction == "left" and "…%s" or "%s…"):format(
+      fn.strcharpart(self.text, start, available_width)
+    )
+  end
+
+  -- `fn.strcharpart` can fail with wide characters. For example,
+  -- `fn.strcharpart("｜", 0, 1)` will still return "｜" since that character
+  -- takes up two columns. This is to handle such cases.
+  if fn.strwidth(self.text) ~= to_width then
+    local fmt = (direction == "left" and "%s…")
+      or (direction == "right" and "…%s")
+      or "%s "
+    self.text = fmt:format(rep(" ", to_width ~= nil and to_width - 1 or 0))
+  end
+
+  self.width = fn.strwidth(self.text)
+end
+
+---@param components  Component[]
+---@return number
+local width_of_components = function(components)
+  return iter(components):fold(0, function(a, c)
+    return a + c.width
+  end)
+end
+
+-- Takes a list of components, returns a new list of components `to_width` wide
+-- obtained by trimming the original `components` in the given `direction`.
+---@generic Cx
+---@param components Component<Cx>[]
+---@param to_width   number
+---@param direction  '"left"' | '"right"' | nil
+---@return Component<Cx>[]
+local shorten_components = function(components, to_width, direction)
+  if #components == 0 then return components end
+
+  local current_width = width_of_components(components)
+
+  -- `extra` is the width of the extra characters that are appended when a
+  -- component is shortened, an ellipses if we're shortening within a buffer
+  -- (in which case the `direction` is `nil`), or an ellipses and a space if
+  -- we're cutting off a component at the edge of the bufferline (where
+  -- `direction` is either `"left"` or `"right"`).
+  local extra = direction and 2 or 1
+  local i = direction == "left" and 1 or #components
+  -- We start from the full list of components and remove components as
+  -- necessary. We could start from an empty list and add until there's space,
+  -- but I think there's usually more components to keep than to throw away, so
+  -- this should be faster in most cases.
+  local last_removed_component
+  while
+    (current_width > to_width)
+    or (current_width - components[i].width + extra > to_width)
+  do
+    local removed = remove(components, i)
+    if removed then
+      last_removed_component = removed
+      current_width = current_width - last_removed_component.width
+      i = direction == "left" and 1 or i - 1
+      if #components == 0 then
+        break
+      end
+    else
+      break
+    end
+  end
+
+  if
+    last_removed_component
+    and (to_width - current_width > extra or #components == 0)
+  then
+    i = direction == "left" and 1 or i + 1
+    last_removed_component:shorten(to_width - current_width, direction)
+    insert(components, i, last_removed_component)
+  else
+    -- Here we "shorten" a component to more than its current width.
+    components[i]:shorten(
+      components[i].width + to_width - current_width,
+      direction
+    )
+  end
+
+  return components
+end
+
+-- Takes in a list of components, returns the concatenation of their rendered
+-- strings.
+---@generic Cx
+---@param components  Component<Cx>[]
+---@return string
+local render_components = function(components)
+  local embed = function(component)
+    local text = component.hlgroup:embed(component.text)
+    if not fn.has("tablineat") then
+      return text
+    else
+      local on_click
+      if component.delete_buffer_on_left_click then
+        on_click = string.format(
+          "v:lua.require'cokeline.handlers'.close_%d",
+          component.bufnr
+        )
+      else
+        on_click = string.format(
+          "v:lua.require'cokeline.handlers'.click_%s_%d_%d",
+          component.kind,
+          component.index,
+          component.bufnr or 0
+        )
+      end
+      return ("%%%s@%s@%s%%X"):format(component.index, on_click, text)
+    end
+  end
+
+  local concat = function(a, b)
+    return a .. b
+  end
+
+  return iter(components):map(embed):fold("", concat)
+end
+
+return {
+  Component = Component,
+  render = render_components,
+  shorten = shorten_components,
+  width = width_of_components,
+}

--- a/lua/plugins/nvim-cokeline/CODES/lua/cokeline/config.lua
+++ b/lua/plugins/nvim-cokeline/CODES/lua/cokeline/config.lua
@@ -1,0 +1,225 @@
+local lazy = require("cokeline.lazy")
+---@module cokeline.state
+local state = lazy("cokeline.state")
+---@module "cokeline.sliders"
+local sliders = lazy("cokeline.sliders")
+---@module "cokeline.hlgroups"
+local hlgroups = lazy("cokeline.hlgroups")
+
+local insert = table.insert
+
+local echo = vim.api.nvim_echo
+local islist = vim.islist or vim.tbl_islist
+
+local defaults = {
+  show_if_buffers_are_at_least = 1,
+
+  buffers = {
+    filter_valid = false,
+    filter_visible = false,
+    focus_on_delete = "next",
+    new_buffers_position = "last",
+    delete_on_right_click = true,
+  },
+
+  mappings = {
+    cycle_prev_next = true,
+    disable_mouse = false,
+  },
+
+  history = {
+    enabled = true,
+    size = 2,
+  },
+
+  rendering = {
+    max_buffer_width = 999,
+    slider = sliders.center_current_buffer,
+  },
+
+  pick = {
+    use_filename = true,
+    letters = "asdfjkl;ghnmxcvbziowerutyqpASDFJKLGHNMXCVBZIOWERUTYQP",
+  },
+
+  default_hl = {
+    fg = function(buffer)
+      return buffer.is_focused and "TabLineSel" or "TabLine"
+    end,
+    bg = function(buffer)
+      return buffer.is_focused and "TabLineSel" or "TabLine"
+    end,
+  },
+
+  fill_hl = "TabLineFill",
+
+  components = {
+    {
+      text = function(buffer)
+        return " " .. buffer.devicon.icon
+      end,
+      fg = function(buffer)
+        return buffer.devicon.color
+      end,
+    },
+    {
+      text = function(buffer)
+        return buffer.unique_prefix
+      end,
+      fg = function()
+        return hlgroups.get_hl_attr("Comment", "fg")
+      end,
+      italic = true,
+    },
+    {
+      text = function(buffer)
+        return buffer.filename
+      end,
+      underline = function(buffer)
+        if buffer.is_hovered and not buffer.is_focused then
+          return true
+        end
+      end,
+    },
+    {
+      text = " ",
+    },
+    {
+      ---@param buffer Buffer
+      text = function(buffer)
+        if buffer.is_modified then
+          return ""
+        end
+        if buffer.is_hovered then
+          return "󰅙"
+        end
+        return "󰅖"
+      end,
+      on_click = function(_, _, _, _, buffer)
+        buffer:delete()
+      end,
+    },
+    {
+      text = " ",
+    },
+  },
+
+  tabs = {
+    placement = "right",
+    components = {},
+  },
+
+  rhs = {},
+
+  sidebar = {
+    filetype = { "NvimTree", "neo-tree", "SidebarNvim" },
+    components = {},
+  },
+}
+
+-- Formats an error message.
+---@param msg  string
+local echoerr = function(msg)
+  echo({
+    { "[nvim-cokeline]: ",     "ErrorMsg" },
+    { 'Configuration option "' },
+    { msg,                     "WarningMsg" },
+    { '" does not exist!' },
+  }, true, {})
+end
+
+local config = vim.deepcopy(defaults)
+
+-- Updates the `settings` table with options from `preferences`, printing an
+-- error message if a configuration option in `preferences` is not defined in
+-- `settings`.
+---@param settings  table
+---@param preferences  table
+---@param key  string | nil
+---@return table
+local function update(settings, preferences, key)
+  local updated = settings
+  for k, v in pairs(preferences) do
+    local key_tree = key and ("%s.%s"):format(key, k) or k
+    if settings[k] == nil and key ~= "default_hl" then
+      echoerr(key_tree)
+    elseif type(v) == "table" and not islist(v) then
+      updated[k] = update(settings[k], v, key_tree)
+    else
+      updated[k] = v
+    end
+  end
+  return updated
+end
+
+local setup = function(opts)
+  config = update(defaults, opts)
+  state.components = {}
+  state.rhs = {}
+  state.sidebar = {}
+  state.tabs = {}
+  local Component = lazy("cokeline.components").Component
+  if opts.buffers and opts.buffers.new_buffers_position then
+    if not config.buffers then
+      config.buffers = {}
+    end
+    config.buffers.new_buffers_position = opts.buffers.new_buffers_position
+  end
+  local id = 1
+  for _, component in ipairs(config.components) do
+    local new_component = Component.new(component, id, opts.default_hl)
+    insert(state.components, new_component)
+    if new_component.on_click ~= nil then
+      require("cokeline.handlers").click:register(id, new_component.on_click)
+    end
+    id = id + 1
+  end
+  if opts.rhs then
+    for _, component in ipairs(config.rhs) do
+      component.kind = "rhs"
+      local new_component = Component.new(component, id, opts.default_hl)
+      insert(state.rhs, new_component)
+      if new_component.on_click ~= nil then
+        require("cokeline.handlers").click:register(id, new_component.on_click)
+      end
+      id = id + 1
+    end
+  end
+  if config.sidebar and config.sidebar.components then
+    for _, component in ipairs(config.sidebar.components) do
+      component.kind = "sidebar"
+      local new_component = Component.new(component, id, opts.default_hl)
+      insert(state.sidebar, new_component)
+      if new_component.on_click ~= nil then
+        require("cokeline.handlers").click:register(id, new_component.on_click)
+      end
+      id = id + 1
+    end
+  end
+  if config.tabs and config.tabs.components then
+    for _, component in ipairs(config.tabs.components) do
+      component.kind = "tab"
+      local new_component = Component.new(component, id, opts.default_hl)
+      insert(state.tabs, new_component)
+      if new_component.on_click ~= nil then
+        require("cokeline.handlers").click:register(id, new_component.on_click)
+      end
+      id = id + 1
+    end
+  end
+  return config
+end
+
+return setmetatable({
+  setup = setup,
+  get = function()
+    return config
+  end,
+}, {
+  __index = function(_, k)
+    return config[k]
+  end,
+  __newindex = function(_, k, v)
+    config[k] = v
+  end,
+})

--- a/lua/plugins/nvim-cokeline/CODES/lua/cokeline/context.lua
+++ b/lua/plugins/nvim-cokeline/CODES/lua/cokeline/context.lua
@@ -1,0 +1,32 @@
+---@alias ContextKind "buffer" | "tab" | "rhs" | "sidebar"
+
+---@class RenderContext
+---@field kind ContextKind
+---@field provider Buffer | TabPage | RhsContext
+local RenderContext = {}
+
+---@param tab TabPage
+function RenderContext:tab(tab)
+  return {
+    provider = tab,
+    kind = "tab",
+  }
+end
+
+---@param rhs RhsContext
+function RenderContext:rhs(rhs)
+  return {
+    provider = rhs,
+    kind = "rhs",
+  }
+end
+
+---@param buffer Buffer
+function RenderContext:buffer(buffer)
+  return {
+    provider = buffer,
+    kind = "buffer",
+  }
+end
+
+return RenderContext

--- a/lua/plugins/nvim-cokeline/CODES/lua/cokeline/handlers.lua
+++ b/lua/plugins/nvim-cokeline/CODES/lua/cokeline/handlers.lua
@@ -1,0 +1,121 @@
+local lazy = require("cokeline.lazy")
+local config = lazy("cokeline.config")
+local utils = lazy("cokeline.utils")
+local buffers = lazy("cokeline.buffers")
+local tabs = lazy("cokeline.tabs")
+
+---@alias ClickHandler fun(button_id: number, clicks: number, button: string, modifiers: string, cx: table)
+---@alias MouseEnterHandler fun(cx: table)
+---@alias MouseLeaveHandler fun(cx: table)
+---@alias Handler ClickHandler | MouseEnterHandler | MouseLeaveHandler
+---@alias WrappedHandler fun(cx: table): Handler
+
+---@class Handlers Singleton event handler manager
+---@field click (fun(cx: table): Handler)[]
+---@field private private table<string, WrappedHandler[]>
+local Handlers = {
+  click = {},
+  private = {
+    click = {},
+  },
+}
+
+---@param kind string
+---@param idx number
+local function unregister(kind, idx)
+  ---@diagnostic disable: cast-local-type
+  if idx == nil then
+    idx = kind
+    kind = nil
+  end
+  rawset(Handlers.private[kind], idx, nil)
+end
+
+---Register a click handler
+---@param idx number
+---@param handler ClickHandler
+function Handlers.click:register(idx, handler)
+  rawset(Handlers.private.click, idx, function(buffer)
+    return function(minwid, clicks, button, modifiers)
+      return handler(minwid, clicks, button, modifiers, buffer)
+    end
+  end)
+end
+
+---Unregister a click handler
+---@param idx number
+function Handlers.click:unregister(idx)
+  unregister("click", idx)
+end
+
+---Default click handler
+---@param cx table
+---@param kind string
+local function default_click(cx, kind)
+  return function(_, _, button)
+    if button == "l" then
+      if kind == "tab" or kind == "buffer" then
+        cx:focus()
+      end
+    elseif
+      kind == "buffer"
+      and button == "r"
+      and config.buffers.delete_on_right_click
+    then
+      utils.buf_delete(cx.number, config.buffers.focus_on_delete)
+    end
+  end
+end
+
+---Default close handler
+---@param buffer bufnr
+local function default_close(buffer)
+  return function(_, _, button)
+    if button == "l" then
+      utils.buf_delete(buffer.number, config.buffers.focus_on_delete)
+    end
+  end
+end
+
+--- Public handlers interface
+return setmetatable({}, {
+  __index = function(_, key)
+    --- Retrieve a helper for registering events
+    local helper = rawget(Handlers, key)
+    if helper ~= nil then
+      return key ~= "private" and helper or nil
+    end
+
+    --- If there's no helper, evaluate the key to get a handler
+    local prefix = string.sub(key, 1, 5)
+    if prefix == "click" then
+      local kind, id, number = string.match(key, "click_(%a+)_(%d+)_(%d+)")
+      if number == nil then
+        return
+      end
+      local cx
+      if kind == "tab" then
+        cx = tabs.get_tabpage(tonumber(number))
+      else
+        cx = buffers.get_buffer(tonumber(number))
+      end
+
+      if id ~= nil then
+        local handler = Handlers.private["click"][tonumber(id)]
+        return handler and handler(cx) or default_click(cx, kind)
+      else
+        return default_click(cx, kind)
+      end
+    elseif prefix == "close" then
+      local bufnr = string.match(key, "close_(%d+)")
+      if bufnr then
+        local buffer = buffers.get_buffer(tonumber(bufnr))
+        return default_close(buffer)
+      end
+    end
+    return nil
+  end,
+  __newindex = function()
+    vim.api.nvim_err_writeln("Cannot set fields in cokeline.handlers")
+  end,
+})

--- a/lua/plugins/nvim-cokeline/CODES/lua/cokeline/history.lua
+++ b/lua/plugins/nvim-cokeline/CODES/lua/cokeline/history.lua
@@ -1,0 +1,124 @@
+local lazy = require("cokeline.lazy")
+local buffers = lazy("cokeline.buffers")
+
+---@class Cokeline.History
+---@field _len integer
+---@field _cap integer
+---@field _data bufnr[]
+local History = {
+  _len = 0,
+  _cap = 4,
+  _data = {},
+  _read = 1,
+  _write = 1,
+}
+
+---Creates a new History object
+---@return Cokeline.History
+function History.setup(cap)
+  History._cap = cap
+  return History
+end
+
+---Adds a Buffer object to the history
+---@param bufnr bufnr
+function History:push(bufnr)
+  self._data[self._write] = bufnr
+  self._write = (self._write % self._cap) + 1
+  if self._len < self._cap then
+    self._len = self._len + 1
+  end
+end
+
+---Removes and returns the oldest Buffer object in the history
+---@return Buffer|nil
+function History:pop()
+  if self._len == 0 then
+    return nil
+  end
+  local bufnr = self._data[self._read]
+  self._data[self._read] = nil
+  self._read = (self._read % self._cap) + 1
+  if bufnr then
+    self._len = self._len - 1
+  end
+  if bufnr then
+    return buffers.get_buffer(bufnr)
+  end
+end
+
+---Returns a list of Buffer objects in the history,
+---ordered from oldest to newest
+---@return Buffer[]
+function History:list()
+  local list = {}
+  local read = self._read
+  for _ = 1, self._len do
+    local buf = self._data[read]
+    if buf then
+      table.insert(list, buffers.get_buffer(buf))
+    end
+    read = (read % self._cap) + 1
+  end
+  return list
+end
+
+---Returns an iterator of Buffer objects in the history,
+---ordered from oldest to newest
+---@return fun():Buffer?
+function History:iter()
+  local read = self._read
+  return function()
+    local buf = self._data[read]
+    if buf then
+      read = read + 1
+      return buffers.get_buffer(buf)
+    end
+  end
+end
+
+---Get a Buffer object by history index
+---@param idx integer
+---@return Buffer|nil
+function History:get(idx)
+  local buf = self._data[(self._read % self._cap) + idx + 1]
+  if buf then
+    return buffers.get_buffer(buf)
+  end
+end
+
+---Get a Buffer object representing the last-accessed buffer (before the current one)
+---@return Buffer|nil
+function History:last()
+  local buf = self._data[self._write == 1 and self._len or (self._write - 1)]
+  if buf then
+    return buffers.get_buffer(buf)
+  end
+end
+
+---Returns true if the history is empty
+---@return boolean
+function History:is_empty()
+  return self._read == self._write
+end
+
+---Returns the maximum number of buffers that can be stored in the history
+---@return integer
+function History:capacity()
+  return self._cap
+end
+
+---Returns true if the history contains the given buffer
+---@param bufnr bufnr
+---@return boolean
+function History:contains(bufnr)
+  return vim.tbl_contains(self._data, bufnr)
+end
+
+---Returns the number of buffers in the history
+---@return integer
+function History:len()
+  return self._len
+end
+
+return History

--- a/lua/plugins/nvim-cokeline/CODES/lua/cokeline/hlgroups.lua
+++ b/lua/plugins/nvim-cokeline/CODES/lua/cokeline/hlgroups.lua
@@ -1,0 +1,133 @@
+local M = {}
+
+-- These functions are called a LOT.
+-- Cache the results to avoid repeat API calls
+local cache = {
+  hex = {},
+  groups = {},
+}
+
+---Clears the hlgroup cache.
+---@private
+function M._cache_clear()
+  cache.groups = {}
+end
+
+---@param rgb integer
+---@return string hex
+function M.hex(rgb)
+  if cache.hex[rgb] then
+    return cache.hex[rgb]
+  end
+  local band, lsr = bit.band, bit.rshift
+
+  local r = lsr(band(rgb, 0xff0000), 16)
+  local g = lsr(band(rgb, 0x00ff00), 8)
+  local b = band(rgb, 0x0000ff)
+
+  local res = ("#%02x%02x%02x"):format(r, g, b)
+  cache.hex[rgb] = res
+  return res
+end
+
+function M.get_hl(name)
+  if cache.groups[name] then
+    return cache.groups[name]
+  end
+  local hl = vim.api.nvim_get_hl(0, { name = name })
+  if not hl then
+    return
+  end
+  if hl.fg and type(hl.fg) == "number" then
+    hl.fg = M.hex(hl.fg)
+  end
+  if hl.bg and type(hl.bg) == "number" then
+    hl.bg = M.hex(hl.bg)
+  end
+  if hl.sp and type(hl.sp) == "number" then
+    hl.sp = M.hex(hl.sp)
+  end
+  cache.groups[name] = hl
+  return hl
+end
+
+function M.get_hl_attr(name, attr)
+  if cache.groups[name] and cache.groups[name][attr] then
+    return cache.groups[name][attr]
+  end
+  local hl = M.get_hl(name)
+  if not hl then
+    return
+  end
+  return hl[attr]
+end
+
+---@class Hlgroup
+---@field name  string
+---@field gui   string
+---@field guifg string
+---@field guibg string
+local Hlgroup = {}
+Hlgroup.__index = Hlgroup
+
+---Sets the highlight group, then returns a new `Hlgroup` table.
+---@param name  string
+---@param fg string
+---@param bg string | nil
+---@param sp string | nil
+---@param gui_attrs table<string, bool>
+---@return Hlgroup
+Hlgroup.new = function(name, fg, bg, sp, gui_attrs)
+  local hlgroup = {}
+  if fg ~= "NONE" and vim.fn.hlexists(fg) == 1 then
+    hlgroup.fg = M.get_hl_attr(fg, "fg")
+  else
+    hlgroup.fg = fg or "NONE"
+  end
+  if bg ~= "NONE" and vim.fn.hlexists(bg) == 1 then
+    hlgroup.bg = M.get_hl_attr(bg, "bg")
+  else
+    hlgroup.bg = bg or "NONE"
+  end
+  if sp and sp ~= "NONE" and vim.fn.hlexists(sp) == 1 then
+    hlgroup.sp = M.get_hl_attr(sp, "sp")
+  else
+    hlgroup.sp = sp or "NONE"
+  end
+
+  for attr, val in pairs(gui_attrs) do
+    if type(val) == "boolean" then
+      hlgroup[attr] = val
+    end
+  end
+
+  hlgroup.default = false
+  vim.api.nvim_set_hl(0, name, hlgroup)
+
+  hlgroup.name = name
+  setmetatable(hlgroup, Hlgroup)
+  return hlgroup
+end
+
+---Using already existing highlight group, returns a new `Hlgroup` table.
+---@param name  string
+---@return Hlgroup
+Hlgroup.new_existing = function(name)
+  local hlgroup = {
+    name = name,
+  }
+  setmetatable(hlgroup, Hlgroup)
+  return hlgroup
+end
+
+---Embeds some text in a highlight group.
+---@param self Hlgroup
+---@param text string
+---@return string
+Hlgroup.embed = function(self, text)
+  return ("%%#%s#%s%%*"):format(self.name, text)
+end
+
+M.Hlgroup = Hlgroup
+
+return M

--- a/lua/plugins/nvim-cokeline/CODES/lua/cokeline/hover.lua
+++ b/lua/plugins/nvim-cokeline/CODES/lua/cokeline/hover.lua
@@ -1,0 +1,335 @@
+local lazy = require("cokeline.lazy")
+local M = {}
+
+local version = vim.version()
+
+local buffers = lazy("cokeline.buffers")
+local config = lazy("cokeline.config")
+local tabs = lazy("cokeline.tabs")
+local rendering = lazy("cokeline.rendering")
+local iter = vim.iter
+local last_position = nil
+
+local hovered
+local dragging
+
+function M.hovered()
+  return hovered
+end
+
+function M.set_hovered(val)
+  hovered = val
+end
+
+function M.clear_hovered()
+  hovered = nil
+end
+
+function M.dragging()
+  return dragging
+end
+
+function M.set_dragging(val)
+  dragging = val
+end
+
+function M.clear_dragging()
+  dragging = nil
+end
+
+function M.get_current(col)
+  local bufs = buffers.get_visible()
+  if not bufs then
+    return
+  end
+  local cx = rendering.prepare(bufs)
+
+  local current_width = 0
+  for _, component in ipairs(cx.sidebar_left) do
+    current_width = current_width + component.width
+    if current_width >= col then
+      return component, cx.sidebar_left
+    end
+  end
+  if config.tabs and config.tabs.placement == "left" then
+    for _, component in ipairs(cx.tabs) do
+      current_width = current_width + component.width
+      if current_width >= col then
+        return component, cx.tabs
+      end
+    end
+  end
+  for _, component in ipairs(cx.buffers) do
+    current_width = current_width + component.width
+    if current_width >= col then
+      return component, cx.buffers
+    end
+  end
+  current_width = current_width + cx.gap
+  if current_width >= col then
+    return
+  end
+  for _, component in ipairs(cx.rhs) do
+    current_width = current_width + component.width
+    if current_width >= col then
+      return component, cx.rhs
+    end
+  end
+  if config.tabs and config.tabs.placement == "right" then
+    for _, component in ipairs(cx.tabs) do
+      current_width = current_width + component.width
+      if current_width >= col then
+        return component, cx.tabs
+      end
+    end
+  end
+  for _, component in ipairs(cx.sidebar_right) do
+    current_width = current_width + component.width
+    if current_width >= col then
+      return component, cx.sidebar_right
+    end
+  end
+end
+
+local function mouse_leave(component)
+  local cx
+  if component.kind == "buffer" then
+    cx = buffers.get_buffer(component.bufnr)
+  elseif component.kind == "tab" then
+    cx = tabs.get_tabpage(component.bufnr)
+  elseif component.kind == "sidebar" then
+    cx = { number = component.bufnr, side = component.sidebar }
+  else
+    cx = {}
+  end
+  if cx then
+    cx.is_hovered = false
+  end
+  if component.on_mouse_leave then
+    if
+      (component.kind ~= "buffer" and component.kind ~= "tab") or cx ~= nil
+    then
+      component.on_mouse_leave(cx)
+    end
+  end
+  M.clear_hovered()
+end
+
+local function mouse_enter(component, current)
+  local cx
+  if component.kind == "buffer" then
+    cx = buffers.get_buffer(component.bufnr)
+  elseif component.kind == "tab" then
+    cx = tabs.get_tabpage(component.bufnr)
+  elseif component.kind == "sidebar" then
+    cx = { number = component.bufnr, side = component.sidebar }
+  else
+    cx = {}
+  end
+  if cx then
+    cx.is_hovered = true
+  end
+  if component.on_mouse_enter then
+    if
+      (component.kind ~= "buffer" and component.kind ~= "tab") or cx ~= nil
+    then
+      component.on_mouse_enter(cx, current.screencol)
+    end
+  end
+  M.set_hovered({
+    index = component.index,
+    bufnr = cx and cx.number,
+    on_mouse_leave = component.on_mouse_leave,
+    kind = component.kind,
+  })
+end
+
+local function on_hover(current)
+  M.clear_dragging()
+  local hovered_component = M.hovered()
+  if vim.o.showtabline == 0 then
+    return
+  end
+  if current.screenrow == 1 then
+    if
+      last_position
+      and hovered_component
+      and last_position.screencol == current.screencol
+    then
+      return
+    end
+    local component = M.get_current(current.screencol)
+
+    if
+      component
+      and hovered_component
+      and component.index == hovered_component.index
+      and component.bufnr == hovered_component.bufnr
+    then
+      return
+    end
+
+    if hovered_component ~= nil then
+      mouse_leave(hovered_component)
+    end
+    if not component then
+      vim.cmd.redrawtabline()
+      return
+    end
+
+    mouse_enter(component, current)
+    vim.cmd.redrawtabline()
+  elseif hovered_component ~= nil then
+    mouse_leave(hovered_component)
+    vim.cmd.redrawtabline()
+  end
+  last_position = current
+end
+
+local function width(bufs, buf)
+  return iter(bufs)
+    :filter(function(v)
+      return v.bufnr == buf
+    end)
+    :map(function(v)
+      return v.width
+    end)
+    :fold(0, function(acc, v)
+      return acc + v
+    end)
+end
+
+local function start_pos(bufs, buf)
+  local pos = 0
+  for _, v in ipairs(bufs) do
+    if v.bufnr == buf then
+      return pos
+    end
+    pos = pos + v.width
+  end
+  return pos
+end
+
+local function on_drag(pos)
+  local hovered_component = M.hovered()
+  if hovered_component then
+    local buf = buffers.get_buffer(hovered_component.bufnr)
+    if buf then
+      buf.is_hovered = false
+    end
+    if hovered_component.kind == "buffer" then
+      if buf and hovered_component.on_mouse_leave then
+        hovered_component.on_mouse_leave(buf)
+      end
+    elseif hovered_component.on_mouse_leave then
+      hovered_component.on_mouse_leave()
+    end
+    M.clear_hovered()
+  end
+  if pos.screenrow ~= 1 then
+    M.clear_dragging()
+    return
+  end
+  if pos.dragging == "l" then
+    local current, bufs = M.get_current(pos.screencol)
+    if current == nil or bufs == nil or current.kind ~= "buffer" then
+      return
+    end
+
+    -- if we're not dragging yet or we're dragging the same buffer, start dragging
+    if M.dragging() == current.bufnr or not M.dragging() then
+      M.set_dragging(current.bufnr)
+      return
+    end
+
+    -- dragged buffer
+    local dragged_buf = buffers.get_buffer(M.dragging())
+    if not dragged_buf then
+      return
+    end
+
+    -- current (hovered) buffer
+    local cur_buf = buffers.get_buffer(current.bufnr)
+    if not cur_buf then
+      return
+    end
+
+    -- start position of dragged buffer
+    local dragging_start = start_pos(bufs, M.dragging())
+    -- width of the current (hovered) buffer
+    local cur_buf_width = width(bufs, current.bufnr)
+
+    if
+      -- buffer is being dragged to the left
+      (
+        dragging_start > pos.screencol
+        and pos.screencol + cur_buf_width > dragging_start
+      )
+      -- buffer is being dragged to the right
+      or dragging_start + cur_buf_width <= pos.screencol
+    then
+      buffers.move_buffer(dragged_buf, cur_buf._valid_index)
+    end
+  end
+end
+
+function M.mouse_pos(drag, key)
+  drag = drag or {}
+  local ok, pos = pcall(vim.fn.getmousepos)
+  if not ok then
+    return
+  end
+
+  return {
+    dragging = type(drag) == "table" and drag[key] or drag,
+    screencol = pos.screencol,
+    screenrow = pos.screenrow,
+    line = pos.line,
+    column = pos.column,
+    winid = pos.winid,
+    winrow = pos.winrow,
+    wincol = pos.wincol,
+  }
+end
+
+function M.setup()
+  if config.mappings.disable_mouse == true or version.minor < 8 then
+    return
+  end
+
+  if version.minor >= 9 and vim.on_key and vim.keycode then
+    local mouse_move = vim.keycode("<MouseMove>")
+    local drag = {
+      [vim.keycode("<LeftDrag>")] = "l",
+      [vim.keycode("<RightDrag>")] = "r",
+      [vim.keycode("<MiddleDrag>")] = "m",
+    }
+    vim.on_key(function(k)
+      local data = M.mouse_pos(drag, k)
+      if data then
+        vim.schedule_wrap(function(key)
+          if key == mouse_move then
+            on_hover(data)
+          elseif drag[key] then
+            on_drag(data)
+          end
+        end)(k)
+      end
+    end)
+  elseif vim.o.mousemoveevent then
+    vim.keymap.set({ "n", "" }, "<MouseMove>", function()
+      local data = M.mouse_pos()
+      if data then
+        on_hover(data)
+      end
+    end)
+    vim.keymap.set({ "n", "" }, "<LeftDrag>", function()
+      local data = M.mouse_pos("l")
+      if data then
+        on_drag(data)
+      end
+    end)
+  end
+end
+
+return M

--- a/lua/plugins/nvim-cokeline/CODES/lua/cokeline/init.lua
+++ b/lua/plugins/nvim-cokeline/CODES/lua/cokeline/init.lua
@@ -1,0 +1,37 @@
+local lazy = require("cokeline.lazy")
+local rendering = lazy("cokeline.rendering")
+local history = lazy("cokeline.history")
+local config = lazy("cokeline.config")
+
+local opt = vim.opt
+
+_G.cokeline = {}
+
+---@param opts table|nil
+local setup = function(opts)
+  config.setup(opts or {})
+  if config.history and config.history.enabled then
+    history.setup(config.history.size)
+  end
+
+  require("cokeline.mappings").setup()
+  require("cokeline.hover").setup()
+  require("cokeline.augroups").setup()
+
+  opt.showtabline = 2
+  opt.tabline = "%!v:lua.cokeline.tabline()"
+end
+
+---@return string
+_G.cokeline.tabline = function()
+  local visible_buffers = require("cokeline.buffers").get_visible()
+  if #visible_buffers < config.show_if_buffers_are_at_least then
+    opt.showtabline = 0
+    return ""
+  end
+  return rendering.render(visible_buffers, config.fill_hl)
+end
+
+return {
+  setup = setup,
+}

--- a/lua/plugins/nvim-cokeline/CODES/lua/cokeline/lazy.lua
+++ b/lua/plugins/nvim-cokeline/CODES/lua/cokeline/lazy.lua
@@ -1,0 +1,10 @@
+return function(module)
+  return setmetatable({}, {
+    __index = function(_, k)
+      return require(module)[k]
+    end,
+    __newindex = function(_, k, v)
+      require(module)[k] = v
+    end,
+  })
+end

--- a/lua/plugins/nvim-cokeline/CODES/lua/cokeline/mappings.lua
+++ b/lua/plugins/nvim-cokeline/CODES/lua/cokeline/mappings.lua
@@ -1,0 +1,255 @@
+local lazy = require("cokeline.lazy")
+local state = lazy("cokeline.state")
+local buffers = lazy("cokeline.buffers")
+
+local cmd = vim.cmd
+local filter = vim.tbl_filter
+local keymap = vim.keymap
+local set_keymap = vim.api.nvim_set_keymap
+local fn = vim.fn
+
+local is_picking = {
+  focus = false,
+  close = false,
+}
+
+---@param goal  '"switch"' | '"focus"' | '"close"' | fun(buf: Buffer)
+---@param index  index
+local by_index = function(goal, index)
+  local target_buffer = filter(function(buffer)
+    return buffer.index == index
+  end, state.visible_buffers)[1]
+
+  if not target_buffer then
+    return
+  end
+
+  if goal == "switch" then
+    local focused_buffer = filter(function(buffer)
+      return buffer.is_focused
+    end, state.valid_buffers)[1]
+
+    if not focused_buffer then
+      return
+    end
+
+    buffers.move_buffer(focused_buffer, target_buffer._valid_index)
+  elseif goal == "focus" then
+    target_buffer:focus()
+  elseif goal == "close" then
+    target_buffer:delete()
+  elseif type(goal) == "function" then
+    goal(target_buffer)
+  end
+end
+
+---@param goal  '"switch"' | '"focus"' |'"close"' | fun(buf: Buffer, did_fallback: boolean)
+---@param step  -1 | 1
+local by_step = function(goal, step)
+  local config = lazy("cokeline.config")
+  local focused_buffer = filter(function(buffer)
+    return buffer.is_focused
+  end, state.valid_buffers)[1]
+
+  local target_buf
+  local target_idx
+  local did_fallback = false
+  if focused_buffer then
+    target_idx = focused_buffer._valid_index + step
+    if target_idx < 1 or target_idx > #state.valid_buffers then
+      if not config.mappings.cycle_prev_next then
+        return
+      end
+      target_idx = (target_idx - 1) % #state.valid_buffers + 1
+    end
+    target_buf = state.valid_buffers[target_idx]
+  elseif goal == "focus" and config.history.enabled then
+    did_fallback = true
+    target_buf = require("cokeline.history"):last()
+    if step < -1 then
+      -- The result of history:last() is the index -1,
+      -- so we need to step back one more.
+      step = step + 1
+    end
+    if target_buf and step ~= 0 then
+      local step_buf = state.valid_buffers[target_buf._valid_index + step]
+      if step_buf then
+        target_buf = step_buf
+      end
+    end
+  else
+    return
+  end
+
+  if target_buf then
+    if goal == "switch" then
+      buffers.move_buffer(focused_buffer, target_idx)
+    elseif goal == "focus" then
+      target_buf:focus()
+    elseif goal == "close" and not did_fallback then
+      target_buf:delete()
+    elseif type(goal) == "function" then
+      goal(target_buf, did_fallback)
+    end
+  end
+end
+
+---@param goal  '"focus"' | '"close"' | '"close-multiple"' | fun(buf: Buffer)
+local pick = function(goal)
+  local close_multiple = false
+  if goal == "close-multiple" then
+    goal = "close"
+    close_multiple = true
+  end
+
+  is_picking[goal] = true
+  cmd("redrawtabline")
+
+  repeat
+    local valid_char, char = pcall(fn.getchar)
+    if not close_multiple then
+      is_picking[goal] = false
+    end
+
+    -- bail out on keyboard interrupt
+    if not valid_char then
+      char = 0
+    end
+
+    local letter = fn.nr2char(char)
+    local target_buffer = filter(function(buffer)
+      return buffer.pick_letter == letter
+    end, state.visible_buffers)[1]
+
+    if not target_buffer or (goal == "focus" and target_buffer.is_focused) then
+      is_picking[goal] = false
+      cmd("redrawtabline")
+      return
+    end
+
+    if goal == "focus" then
+      target_buffer:focus()
+    elseif goal == "close" then
+      target_buffer:delete()
+    elseif type(goal) == "function" then
+      goal(target_buffer)
+    end
+  until not is_picking[goal]
+end
+
+local setup = function()
+  if keymap then
+    keymap.set("n", "<Plug>(cokeline-switch-prev)", function()
+      by_step("switch", -1)
+    end)
+
+    keymap.set("n", "<Plug>(cokeline-switch-next)", function()
+      by_step("switch", 1)
+    end)
+
+    keymap.set("n", "<Plug>(cokeline-focus-prev)", function()
+      by_step("focus", -1)
+    end)
+
+    keymap.set("n", "<Plug>(cokeline-focus-next)", function()
+      by_step("focus", 1)
+    end)
+
+    keymap.set("n", "<Plug>(cokeline-pick-focus)", function()
+      pick("focus")
+    end)
+
+    keymap.set("n", "<Plug>(cokeline-pick-close)", function()
+      pick("close")
+    end)
+
+    keymap.set("n", "<Plug>(cokeline-pick-close-multiple)", function()
+      pick("close-multiple")
+    end)
+
+    for i = 1, 20 do
+      keymap.set("n", ("<Plug>(cokeline-switch-%s)"):format(i), function()
+        by_index("switch", i)
+      end, {})
+
+      keymap.set("n", ("<Plug>(cokeline-focus-%s)"):format(i), function()
+        by_index("focus", i)
+      end, {})
+    end
+  else
+    set_keymap(
+      "n",
+      "<Plug>(cokeline-switch-prev)",
+      '<Cmd>lua require"cokeline/mappings".by_step("switch", -1)<CR>',
+      {}
+    )
+    set_keymap(
+      "n",
+      "<Plug>(cokeline-switch-next)",
+      '<Cmd>lua require"cokeline/mappings".by_step("switch", 1)<CR>',
+      {}
+    )
+    set_keymap(
+      "n",
+      "<Plug>(cokeline-focus-prev)",
+      '<Cmd>lua require"cokeline/mappings".by_step("focus", -1)<CR>',
+      {}
+    )
+    set_keymap(
+      "n",
+      "<Plug>(cokeline-focus-next)",
+      '<Cmd>lua require"cokeline/mappings".by_step("focus", 1)<CR>',
+      {}
+    )
+    set_keymap(
+      "n",
+      "<Plug>(cokeline-pick-focus)",
+      '<Cmd>lua require"cokeline/mappings".pick("focus")<CR>',
+      {}
+    )
+    set_keymap(
+      "n",
+      "<Plug>(cokeline-pick-close)",
+      '<Cmd>lua require"cokeline/mappings".pick("close")<CR>',
+      {}
+    )
+    set_keymap(
+      "n",
+      "<Plug>(cokeline-pick-close-multiple)",
+      '<Cmd>lua require"cokeline/mappings".pick("close-multiple")<CR>',
+      {}
+    )
+    for i = 1, 20 do
+      set_keymap(
+        "n",
+        ("<Plug>(cokeline-switch-%s)"):format(i),
+        ('<Cmd>lua require"cokeline/mappings".by_index("switch", %s)<CR>'):format(
+          i
+        ),
+        {}
+      )
+
+      set_keymap(
+        "n",
+        ("<Plug>(cokeline-focus-%s)"):format(i),
+        ('<Cmd>lua require"cokeline/mappings".by_index("focus", %s)<CR>'):format(
+          i
+        ),
+        {}
+      )
+    end
+  end
+end
+
+return {
+  by_index = by_index,
+  by_step = by_step,
+  is_picking_focus = function()
+    return is_picking.focus
+  end,
+  is_picking_close = function()
+    return is_picking.close
+  end,
+  pick = pick,
+  setup = setup,
+}

--- a/lua/plugins/nvim-cokeline/CODES/lua/cokeline/rendering.lua
+++ b/lua/plugins/nvim-cokeline/CODES/lua/cokeline/rendering.lua
@@ -1,0 +1,260 @@
+local lazy = require("cokeline.lazy")
+local state = lazy("cokeline.state")
+local config = lazy("cokeline.config")
+local components = lazy("cokeline.components")
+local sidebar = lazy("cokeline.sidebar")
+local rhs = lazy("cokeline.rhs")
+local tabs = lazy("cokeline.tabs")
+local RenderContext = lazy("cokeline.context")
+local iter = vim.iter
+
+local insert = table.insert
+local sort = table.sort
+local unpack = unpack or table.unpack
+
+local extend = vim.list_extend
+local o = vim.o
+
+---@type index
+local current_index
+
+---@param buffers  Buffer[]
+---@param previous_buffer_index  index
+---@return Buffer
+local find_current_buffer = function(buffers, previous_buffer_index)
+  local focused_buffer = iter(buffers):find(function(buffer)
+    return buffer.is_focused
+  end)
+
+  return focused_buffer or buffers[previous_buffer_index] or buffers[#buffers]
+end
+
+---@param c1  Component
+---@param c2  Component
+---@return boolean
+local by_decreasing_priority = function(c1, c2)
+  return c1.truncation.priority < c2.truncation.priority
+end
+
+---@param c1  Component
+---@param c2  Component
+---@return boolean
+local by_increasing_index = function(c1, c2)
+  return c1.index < c2.index
+end
+
+-- Takes in either a single buffer or a list of buffers, and it returns a list
+-- of all the rendered components together with their total combined width.
+---@param context Buffer|Buffer[]|TabPage|TabPage[]
+---@param complist Component[]
+---@return Component, number
+local function to_components(context, complist)
+  local hovered = require("cokeline.hover").hovered()
+  -- A simple heuristic to check if we're dealing with single buffer or a list
+  -- of them is to just check if one of they keys is defined.
+  if context.number then
+    local cs = {}
+    for _, c in ipairs(complist) do
+      local render_cx
+      if context.filetype then
+        render_cx = RenderContext:buffer(context)
+        render_cx.provider.buf_hovered = hovered ~= nil
+          and hovered.bufnr == context.number
+      else
+        render_cx = RenderContext:tab(context)
+        render_cx.provider.tab_hovered = hovered ~= nil
+          and hovered.bufnr == context.number
+      end
+      render_cx.provider.is_hovered = hovered ~= nil
+        and hovered.bufnr == context.number
+        and hovered.index == c.index
+      local rendered = c:render(render_cx)
+      render_cx.provider.is_hovered = false
+      if rendered.width > 0 then
+        insert(cs, rendered)
+      end
+    end
+
+    local width = components.width(cs)
+    if width <= config.rendering.max_buffer_width then
+      return cs, width
+    else
+      sort(cs, by_decreasing_priority)
+      components.shorten(cs, config.rendering.max_buffer_width)
+      sort(cs, by_increasing_index)
+      return cs, config.rendering.max_buffer_width
+    end
+  else
+    local cs = {}
+    local width = 0
+    for _, buffer in ipairs(context) do
+      local buf_components, buf_width = to_components(buffer, complist)
+      width = width + buf_width
+      for _, component in pairs(buf_components) do
+        insert(cs, component)
+      end
+    end
+    return cs, width
+  end
+end
+
+---This is a helper function for rendering and hover handers. It takes
+---the list of visible buffers, figures out which components to display, and
+---returns a list of pre-render components
+---@param visible_buffers  Buffer[]
+---@return table|string
+local prepare = function(visible_buffers)
+  local sidebar_components_l = sidebar.get_components("left")
+  local sidebar_components_r = sidebar.get_components("right")
+  local rhs_components = rhs.get_components()
+  local available_width = o.columns - components.width(sidebar_components_l)
+  if available_width == 0 then
+    return components.render(sidebar_components_l)
+  end
+
+  local tab_placement
+  local tab_components
+  local tabs_width
+  if config.tabs then
+    tab_placement = config.tabs.placement or "left"
+    tab_components = to_components(tabs.get_tabs(), state.tabs)
+    tabs_width = components.width(tab_components)
+    available_width = available_width - tabs_width
+    if available_width == 0 then
+      return components.render(sidebar_components_l)
+        .. components.render(tab_components)
+    end
+  end
+
+  local current_buffer = find_current_buffer(visible_buffers, current_index)
+
+  local current_components, current_width
+  if current_buffer then
+    current_index = current_buffer.index
+
+    current_components, current_width =
+      to_components(current_buffer, state.components)
+    if current_width >= available_width then
+      sort(current_components, by_decreasing_priority)
+      components.shorten(current_components, available_width)
+      sort(current_components, by_increasing_index)
+      if current_buffer.index > 1 then
+        components.shorten(current_components, available_width, "left")
+      end
+      if current_buffer.index < #visible_buffers then
+        components.shorten(current_components, available_width, "right")
+      end
+
+      return {
+        sidebar_left = sidebar_components_l,
+        sidebar_right = sidebar_components_r,
+        buffers = current_components,
+        rhs = rhs_components,
+        tabs = tab_components,
+        gap = math.max(
+          0,
+          available_width
+            - (
+              components.width(current_components)
+              + components.width(rhs_components)
+            )
+        ),
+      }
+    end
+  else
+    current_components, current_width = {}, 0
+  end
+
+  local left_components, left_width
+  local right_components, right_width
+  if #visible_buffers > 0 then
+    left_components, left_width = to_components({
+      unpack(visible_buffers, 1, current_buffer.index - 1),
+    }, state.components)
+
+    right_components, right_width = to_components({
+      unpack(visible_buffers, current_buffer.index + 1, #visible_buffers),
+    }, state.components)
+  else
+    left_components, left_width = {}, 0
+    right_components, right_width = {}, 0
+  end
+
+  local rhs_width = components.width(rhs_components)
+    + components.width(sidebar_components_r)
+  local available_width_left, available_width_right = config.rendering.slider(
+    available_width
+      - current_width
+      - rhs_width
+      - ((tabs_width ~= nil and tab_placement == "right") and tabs_width or 0),
+    left_width,
+    right_width
+  )
+
+  -- If we handled left, current and right components separately we might have
+  -- to shorten the left or right components with a `to_width` parameter of 1,
+  -- in which case the correct behaviour would be to "shorten" the current
+  -- buffer components instead.
+  --
+  -- To avoid this, we join all the buffer components together *before*
+  -- checking if they need to be shortened.
+  local buffer_components =
+    extend(extend(left_components, current_components), right_components)
+
+  if left_width > available_width_left then
+    components.shorten(
+      buffer_components,
+      available_width_left + current_width + right_width,
+      "left"
+    )
+  end
+  if right_width > available_width_right then
+    components.shorten(buffer_components, available_width - rhs_width, "right")
+  end
+
+  local bufs_width = components.width(buffer_components)
+  return {
+    sidebar_left = sidebar_components_l,
+    sidebar_right = sidebar_components_r,
+    buffers = buffer_components,
+    rhs = rhs_components,
+    tabs = tab_components,
+    gap = math.max(0, available_width - (bufs_width + rhs_width)),
+  }
+end
+
+---This is the main function responsible for rendering the bufferline. It takes
+---the list of visible buffers, figures out which components to display and
+---returns their rendered version.
+---@param visible_buffers  Buffer[]
+---@param fill_hl string
+---@return string
+local render = function(visible_buffers, fill_hl)
+  local cx = prepare(visible_buffers)
+  local rendered = components.render(cx.sidebar_left) .. "%#" .. fill_hl .. "#"
+  if config.tabs and config.tabs.placement == "left" then
+    rendered = rendered .. components.render(cx.tabs) .. "%#" .. fill_hl .. "#"
+  end
+  rendered = "%#"
+    .. fill_hl
+    .. "#"
+    .. rendered
+    .. components.render(cx.buffers)
+    .. "%#"
+    .. fill_hl
+    .. "#"
+    .. string.rep(" ", cx.gap)
+    .. components.render(cx.rhs)
+  if config.tabs and config.tabs.placement == "right" then
+    rendered = rendered .. "%#" .. fill_hl .. "#" .. components.render(cx.tabs)
+  end
+  rendered = rendered .. components.render(cx.sidebar_right)
+  return rendered
+end
+
+return {
+  by_decreasing_priority = by_decreasing_priority,
+  by_increasing_index = by_increasing_index,
+  prepare = prepare,
+  render = render,
+}

--- a/lua/plugins/nvim-cokeline/CODES/lua/cokeline/rhs.lua
+++ b/lua/plugins/nvim-cokeline/CODES/lua/cokeline/rhs.lua
@@ -1,0 +1,30 @@
+local lazy = require("cokeline.lazy")
+local state = lazy("cokeline.state")
+local components = lazy("cokeline.components")
+local RenderContext = lazy("cokeline.context")
+
+local M = {}
+
+---@class RhsContext
+---@field is_hovered boolean
+
+function M.get_components()
+  local hovered = lazy("cokeline.hover").hovered()
+  local rhs = {}
+  for _, c in ipairs(state.rhs) do
+    local is_hovered = hovered and hovered.index == c.index
+    table.insert(
+      rhs,
+      c:render(RenderContext:rhs({
+        is_hovered = is_hovered,
+      }, "rhs"))
+    )
+  end
+  return rhs
+end
+
+function M.width()
+  return components.width(M.get_components())
+end
+
+return M

--- a/lua/plugins/nvim-cokeline/CODES/lua/cokeline/sidebar.lua
+++ b/lua/plugins/nvim-cokeline/CODES/lua/cokeline/sidebar.lua
@@ -1,0 +1,165 @@
+local lazy = require("cokeline.lazy")
+local config = lazy("cokeline.config")
+local state = lazy("cokeline.state")
+local Buffer = lazy("cokeline.buffers").Buffer
+local components = lazy("cokeline.components")
+local RenderContext = lazy("cokeline.context")
+
+local min = math.min
+local rep = string.rep
+local insert = table.insert
+local sort = table.sort
+
+local api = vim.api
+local bo = vim.bo
+local fn = vim.fn
+local o = vim.o
+
+local width_cache = {}
+
+local get_win = function(side)
+  local layout = fn.winlayout()
+  if not layout then
+    return
+  end
+
+  -- If the first split level is not given by vertically split windows we
+  -- return early and invalidate the width cache.
+  if layout[1] ~= "row" then
+    width_cache = {}
+    return nil
+  end
+
+  -- The second element of the `layout` table is a nested list representing the
+  -- tree of vertically split windows in a tabpage. For example, for a layout
+  -- like.
+  -- +-----+-----+-----+
+  -- |     |     |  C  |
+  -- |  A  |  B  |-----|
+  -- |     |     |  D  |
+  -- +-----+-----+-----+
+  -- the associated tree would be
+  --        / | \
+  --       /  |  \
+  --      A   B  / \
+  --             C  D
+  -- where each leaf is represented as a `{'leaf', <winid>}` table.
+  local window_tree = layout[2]
+
+  -- Since we're checking if we need to display sidebars we're only
+  -- interested in the first and last window splits.
+  --
+  -- However, with edgy.nvim, a sidebar can contain multiple splits nested one level in.
+  -- So if the first window found is a leaf, we check the first window of the container.
+  local first_split
+  local winid
+  if side == nil or side == "left" then
+    first_split = window_tree[1]
+    winid = first_split[2]
+    if first_split[1] ~= "leaf" then
+      local win = first_split[2][1]
+      if win and win[1] == "leaf" then
+        winid = win[2]
+      else
+        width_cache[side] = nil
+        return nil
+      end
+    end
+  else
+    first_split = window_tree[#window_tree]
+    winid = first_split[2]
+    if first_split[1] ~= "leaf" then
+      local win = first_split[2][#first_split[2]]
+      if win and win[1] == "leaf" then
+        winid = win[2]
+      else
+        width_cache[side] = nil
+        return nil
+      end
+    end
+  end
+  width_cache[side] = api.nvim_win_get_width(winid)
+  return winid
+end
+
+---@param side "left" | "right"
+---@return Component<Buffer>[]
+local get_components = function(side)
+  if not config.sidebar then
+    return {}
+  end
+
+  local winid = get_win(side)
+  if not winid then
+    return {}
+  end
+
+  local bufnr = api.nvim_win_get_buf(winid)
+
+  if type(config.sidebar.filetype) == "table" then
+    if not vim.tbl_contains(config.sidebar.filetype, bo[bufnr].filetype) then
+      return {}
+    end
+  else
+    if bo[bufnr].filetype ~= config.sidebar.filetype then
+      return {}
+    end
+  end
+
+  local buffer = Buffer.new({
+    bufnr = bufnr,
+    name = fn.bufname(4),
+  })
+  local sidebar_width = min(api.nvim_win_get_width(winid), o.columns)
+
+  local sidebar_components = {}
+  local width = 0
+  local id = #state.components + #state.rhs + 1
+  local hover = lazy("cokeline.hover").hovered()
+  buffer.buf_hovered = hover ~= nil and hover.bufnr == buffer.number
+  if not state.sidebar or not next(state.sidebar) then
+    -- Fix(170): Return early as we have no sidebar components to handle
+    return sidebar_components
+  end
+  for _, c in ipairs(state.sidebar) do
+    c.sidebar = side
+    buffer.is_hovered = hover ~= nil
+      and hover.index == id
+      and hover.bufnr == buffer.number
+    local component = c:render(RenderContext:buffer(buffer))
+    buffer.is_hovered = false
+    -- We need at least one component, otherwise we can't add padding to the
+    -- last component if needed.
+    if component.width > 0 or #sidebar_components == 0 then
+      insert(sidebar_components, component)
+      width = width + component.width
+    end
+    id = id + 1
+  end
+
+  local rendering = lazy("cokeline.rendering")
+
+  if width > sidebar_width then
+    sort(sidebar_components, rendering.by_decreasing_priority)
+    components.shorten(sidebar_components, sidebar_width)
+    sort(sidebar_components, rendering.by_increasing_index)
+  elseif width < sidebar_width then
+    local space_left = sidebar_width - width
+    local last = #sidebar_components
+    sidebar_components[last].text = sidebar_components[last].text
+      .. rep(" ", space_left)
+    sidebar_components[last].width = sidebar_components[last].width
+      + space_left
+  end
+
+  return sidebar_components
+end
+
+return {
+  get_win = get_win,
+  get_components = get_components,
+  ---@return integer
+  get_width = function(side)
+    return width_cache[side] or 0
+  end,
+}

--- a/lua/plugins/nvim-cokeline/CODES/lua/cokeline/sliders.lua
+++ b/lua/plugins/nvim-cokeline/CODES/lua/cokeline/sliders.lua
@@ -1,0 +1,78 @@
+-- local math_abs = math.abs
+local floor = math.floor
+local max = math.max
+
+---@type table
+-- local gl_mut_prev_state
+
+-- local gl_scrolloff = 5
+
+---@param available_space  number
+---@param width_left_of_current  number
+---@param width_right_of_current  number
+---@return number, number
+local center_current_buffer = function(
+  available_space,
+  width_left_of_current,
+  width_right_of_current
+)
+  local available_space_left = floor(available_space / 2)
+  local available_space_right = available_space_left + available_space % 2
+
+  local unused_space_left =
+    max(available_space_left - width_left_of_current, 0)
+  local unused_space_right =
+    max(available_space_right - width_right_of_current, 0)
+
+  return available_space_left - unused_space_left + unused_space_right,
+    available_space_right - unused_space_right + unused_space_left
+end
+
+---@param available_space  number
+---@param width_left_of_current  number
+---@param width_right_of_current  number
+---@return number, number
+-- local slide_if_needed =
+--   function(available_space, width_left_of_current, width_right_of_current,
+--             current_buffer_index, prev_state)
+
+--   -- The first time the bufferline is rendered there is no previous state, so..
+--   if not gl_mut_prev_state then
+--     return 0, available_space
+--   end
+
+--   -- If the new current buffer was not fully in view in the previous state we..
+--   if current_buffer_index < prev_state.fully_in_view[1].index then
+--     local left =
+--       gl_scrolloff < width_left_of_current
+--       and gl_scrolloff
+--        or width_left_of_current
+--     local right = available_space - left
+--     return left, right
+
+--   elseif current_buffer_index >
+--           prev_state.fully_in_view[#prev_state.fully_in_view].index then
+--     local right =
+--       gl_scrolloff < width_right_of_current
+--       and gl_scrolloff
+--        or width_right_of_current
+--     local left = available_space - right
+--     return left, right
+--   end
+
+--   local index_range = math_abs(current_buffer_index - prev_state.current_index)
+--   local j = prev_state.current_index < current_buffer_index and 1 or -1
+
+--   local left, right = prev_state.spaces.left, prev_state.spaces.right
+--   for i=1,index_range do
+--     left = left + j * prev_state.fully_in_view[i].width
+--     right = right - j * prev_state.fully_in_view[i + 1].width
+--   end
+
+--   return left, right
+-- end
+
+return {
+  center_current_buffer = center_current_buffer,
+  -- slide_if_needed = slide_if_needed,
+}

--- a/lua/plugins/nvim-cokeline/CODES/lua/cokeline/state.lua
+++ b/lua/plugins/nvim-cokeline/CODES/lua/cokeline/state.lua
@@ -1,0 +1,25 @@
+local M = {}
+
+M.tab_cache = {}
+
+M.tab_lookup = {}
+
+M.valid_lookup = {}
+
+M.visible_buffers = {}
+
+M.valid_buffers = {}
+
+---@type Component<Buffer>[]
+M.components = {}
+
+---@type Component<RhsContext>[]
+M.rhs = {}
+
+---@type Component<SidebarContext>[]
+M.sidebar = {}
+
+---@type Component<TabPage>[]
+M.tabs = {}
+
+return M

--- a/lua/plugins/nvim-cokeline/CODES/lua/cokeline/tabs.lua
+++ b/lua/plugins/nvim-cokeline/CODES/lua/cokeline/tabs.lua
@@ -1,0 +1,140 @@
+local lazy = require("cokeline.lazy")
+local state = lazy("cokeline.state")
+local buffers = lazy("cokeline.buffers")
+local Buffer = buffers.Buffer
+
+local M = {}
+
+---@class Window
+---@field number window
+---@field buffer Buffer
+local Window = {}
+Window.__index = Window
+
+function Window.new(winnr)
+  local bufnr = vim.api.nvim_win_get_buf(winnr)
+  local win = {
+    number = winnr,
+    buffer = buffers.get_buffer(bufnr)
+      or Buffer.new({ bufnr = bufnr, name = vim.api.nvim_buf_get_name(bufnr) }),
+  }
+  return setmetatable(win, Window)
+end
+
+function Window:close()
+  pcall(vim.api.nvim_win_close, self.number, false)
+end
+
+function Window:focus()
+  vim.api.nvim_set_current_win(self.number)
+end
+
+---@class TabPage
+---@field number tabpage
+---@field index number
+---@field windows Window[]
+---@field focused Window
+---@field is_first boolean
+---@field is_last boolean
+---@field is_active boolean
+---@field is_hovered boolean  Whether the current component is hovered
+---@field tab_hovered boolean Whether the tab is hovered
+local TabPage = {}
+TabPage.__index = TabPage
+
+function TabPage.new(tabnr, index, is_first, is_last, is_active)
+  local active_win = vim.api.nvim_tabpage_get_win(tabnr)
+  local windows = vim.api.nvim_tabpage_list_wins(tabnr)
+
+  local focused
+  for i, winnr in ipairs(windows) do
+    windows[i] = Window.new(winnr)
+    if winnr == active_win then
+      focused = windows[i]
+    end
+  end
+
+  local tab = {
+    number = tabnr,
+    index = index,
+    windows = windows,
+    focused = focused,
+    is_active = is_active,
+    is_first = is_first,
+    is_last = is_last,
+  }
+  return setmetatable(tab, TabPage)
+end
+
+function TabPage:focus()
+  vim.api.nvim_set_current_tabpage(self.number)
+end
+
+function TabPage:close()
+  for _, win in ipairs(self.windows) do
+    win:close()
+  end
+end
+
+function M.update_current(tabnr)
+  for _, t in ipairs(state.tab_cache) do
+    if t.number == tabnr then
+      t.is_active = true
+    else
+      t.is_active = false
+    end
+  end
+end
+
+function M.fetch_tabs()
+  local tabs = {}
+  local tabnrs = vim.api.nvim_list_tabpages()
+  local active_tab = vim.api.nvim_get_current_tabpage()
+  table.sort(tabnrs, function(a, b)
+    return a < b
+  end)
+  for _, tabnr in ipairs(tabnrs) do
+    local t = vim.api.nvim_tabpage_get_number(tabnr)
+    if state.tab_lookup[tabnr] ~= nil then
+      tabs[t] = state.tab_lookup[tabnr]
+      tabs[t].is_active = tabnr == active_tab
+      tabs[t].is_first = t == 1
+      tabs[t].is_last = t == #tabnrs
+      tabs[t].index = t
+      local windows = vim.api.nvim_tabpage_list_wins(tabnr)
+      for i, winnr in ipairs(windows) do
+        if
+          tabs[t].windows[i] == nil
+          or tabs[t].windows[i].buffer == nil
+          or tabs[t].windows[i].buffer.number
+            ~= vim.api.nvim_win_get_buf(winnr)
+        then
+          tabs[t].windows[i] = Window.new(winnr)
+        end
+      end
+    else
+      tabs[t] =
+        TabPage.new(tabnr, t, t == 1, t == #tabnrs, tabnr == active_tab)
+      state.tab_lookup[tabnr] = tabs[t]
+    end
+  end
+  state.tab_cache = tabs
+end
+
+function M.get_tabs()
+  local cache_count = state.tab_cache and #state.tab_cache or nil
+  if
+    cache_count == nil
+    or cache_count == 0
+    or cache_count ~= #vim.api.nvim_list_tabpages()
+  then
+    M.fetch_tabs()
+  end
+  return state.tab_cache
+end
+
+function M.get_tabpage(tabnr)
+  return state.tab_lookup[tabnr]
+end
+
+return M

--- a/lua/plugins/nvim-cokeline/CODES/lua/cokeline/utils.lua
+++ b/lua/plugins/nvim-cokeline/CODES/lua/cokeline/utils.lua
@@ -1,0 +1,121 @@
+---@param bufnr number
+---@param focus_next boolean
+---@param wipeout boolean
+---@param force boolean
+local function buf_del_impl(bufnr, focus_next, wipeout, force)
+  local win = vim.fn.bufwinid(bufnr)
+
+  if win ~= -1 then
+    -- Get a list of buffers that are valid switch targets
+    local switchable = vim.tbl_filter(function(buf)
+      return vim.api.nvim_buf_is_valid(buf)
+        and vim.bo[buf].buflisted
+        and buf ~= bufnr
+    end, vim.api.nvim_list_bufs())
+
+    local switch_target
+    if #switchable > 0 then
+      for _, switch_nr in ipairs(switchable) do
+        -- If we're looking for a buffer after the current one, break here
+        if switch_nr < bufnr then
+          -- Keep looping to find the previous buffer
+          -- This also serves as a fallback if there's no
+          -- next buffer, and `focus_next` is true
+          switch_target = switch_nr
+        end
+        if switch_nr > bufnr and (focus_next or switch_target == nil) then
+          -- We found the next buffer, break
+          switch_target = switch_nr
+          break
+        end
+      end
+    else
+      -- If there's no possible switch target, create a new buffer and switch to it
+      switch_target = vim.api.nvim_create_buf(false, true)
+      if switch_target == 0 then
+        vim.api.nvim_err_writeln("Failed to create new buffer")
+      end
+    end
+
+    vim.api.nvim_win_set_buf(win, switch_target)
+  end
+
+  if vim.api.nvim_buf_is_valid(bufnr) then
+    if wipeout then
+      vim.cmd.bwipeout({ count = bufnr })
+    else
+      vim.api.nvim_buf_delete(bufnr, { force = force })
+    end
+  end
+end
+
+---@param bufnr bufnr The buffer to delete
+---@param focus "prev" | "next" | nil Buffer to focus on deletion (default: "next")
+---@param wipeout boolean Whether to wipe the buffer (default: false)
+---Deletes a buffer but keeps window layout
+local function buf_delete(bufnr, focus, wipeout)
+  bufnr = bufnr or 0
+  wipeout = wipeout or false
+  local focus_next = true
+
+  if focus == "prev" then
+    focus_next = false
+  end
+
+  if vim.bo[bufnr].modified then
+    vim.ui.select({
+      "Save and close",
+      "Discard changes and close",
+      "Cancel",
+    }, {
+      prompt = string.format(
+        "Buffer %s has unsaved changes.",
+        vim.fn.fnamemodify(vim.fn.bufname(bufnr), ":f")
+      ),
+    }, function(_, choice)
+      if choice == 1 then
+        if vim.api.nvim_buf_get_name(bufnr) == "" then
+          vim.ui.input({
+            prompt = "File name: ",
+            completion = "file",
+          }, function(name)
+            if name and name ~= "" then
+              vim.api.nvim_buf_set_name(bufnr, name)
+              vim.api.nvim_buf_call(bufnr, vim.cmd.write)
+              buf_del_impl(bufnr, focus_next, wipeout, false)
+            end
+          end)
+        else
+          vim.api.nvim_buf_call(bufnr, vim.cmd.write)
+          buf_del_impl(bufnr, focus_next, wipeout, false)
+        end
+      elseif choice == 2 then
+        buf_del_impl(bufnr, focus_next, wipeout, true)
+      elseif choice == 3 then
+        return
+      end
+    end)
+  elseif vim.bo[bufnr].buftype == "terminal" then
+    vim.ui.select({
+      "Quit",
+      "Cancel",
+    }, {
+      prompt = string.format(
+        "Buffer %s is a terminal, and is still running.",
+        vim.fn.fnamemodify(vim.fn.bufname(bufnr), ":t")
+      ),
+    }, function(_, choice)
+      if choice == 1 then
+        buf_del_impl(bufnr, focus_next, wipeout, true)
+      elseif choice == 2 then
+        return
+      end
+    end)
+  else
+    buf_del_impl(bufnr, focus_next, wipeout, false)
+  end
+end
+
+return {
+  buf_delete = buf_delete,
+}

--- a/lua/plugins/nvim-cokeline/CODES/lua/resession/extensions/cokeline.lua
+++ b/lua/plugins/nvim-cokeline/CODES/lua/resession/extensions/cokeline.lua
@@ -1,0 +1,21 @@
+local M = {}
+
+function M.on_save()
+  local files = {}
+  for entry in require("cokeline.history"):iter() do
+    table.insert(files, entry.path)
+  end
+  return files
+end
+
+function M.on_post_load(data)
+  local history = require("cokeline.history")
+  for _, path in ipairs(data) do
+    local buf = vim.fn.bufnr(path)
+    if buf then
+      history:push(buf)
+    end
+  end
+end
+
+return M

--- a/lua/plugins/nvim-cokeline/CODES/neovim.yml
+++ b/lua/plugins/nvim-cokeline/CODES/neovim.yml
@@ -1,0 +1,25 @@
+---
+base: lua51
+
+globals:
+  vim:
+    any: true
+  assert:
+    args:
+      - type: bool
+      - type: string
+        required: false
+  after_each:
+    args:
+      - type: function
+  before_each:
+    args:
+      - type: function
+  describe:
+    args:
+      - type: string
+      - type: function
+  it:
+    args:
+      - type: string
+      - type: function

--- a/lua/plugins/nvim-cokeline/CODES/selene.toml
+++ b/lua/plugins/nvim-cokeline/CODES/selene.toml
@@ -1,0 +1,5 @@
+std = "neovim"
+
+[rules]
+global_usage = "allow"
+multiple_statements = "allow"

--- a/lua/plugins/nvim-cokeline/CODES/stylua.toml
+++ b/lua/plugins/nvim-cokeline/CODES/stylua.toml
@@ -1,0 +1,3 @@
+column_width = 79
+indent_type = "Spaces"
+indent_width = 2

--- a/lua/plugins/nvim-cokeline/WIKIS/Buffer.md
+++ b/lua/plugins/nvim-cokeline/WIKIS/Buffer.md
@@ -1,0 +1,133 @@
+# Buffer
+
+Some of the configuration options can be functions that take a `Buffer` as a
+single parameter. This is useful as it allows users to set the values of
+components dynamically based on the buffer that component is being rendered
+for.
+
+```lua
+Buffer = {
+  index = integer,
+  number = integer,
+  type = string,
+  is_focused = boolean,
+  is_modified = boolean,
+  is_readonly = boolean,
+  path = string,
+  unique_prefix = string,
+  filename = string,
+  filetype = string,
+  pick_letter = char,
+  devicon = { icon = string, color = string },
+  diagnostics = {
+    errors = integer,
+    warnings = integer,
+    infos = integer,
+    hints = integer
+  }
+}
+```
+
+## Properties
+
+### index: integer
+
+The buffer's order in the bufferline (1 for the first buffer, 2 for the second one, etc.).
+
+### number: integer
+
+The buffer's internal number as reported by `:ls`
+
+### is_focused: boolean
+
+Whether the buffer is currently focused
+
+### is_modified: boolean
+
+### is_readonly: boolean
+
+### is_first: boolean
+
+The buffer is the first visible buffer in the tab bar.
+
+### is_last: boolean
+
+The buffer is the last visible buffer in the tab bar.
+
+### is_hovered: boolean
+
+The mouse is hovering over the buffer
+This is a special variable in that it will only be true for the hovered *component* on render. This is to allow components to respond to hover events individually without managing component state. If you just need the hovered bufnr, you can use `require('cokeline.hover').hovered().bufnr`.
+
+### type: string
+
+The buffer's type as reported by `:echo &buftype`.
+
+### filetype: string
+
+The buffer's filetype as reported by `:echo &filetype`.
+
+### path: string
+
+The buffer's full path
+
+### filename: string
+
+The buffer's filename
+
+### unique_prefix: string
+
+A unique prefix used to distinguish buffers with the same filename stored in different directories. For example, if we have two files `bar/foo.md` and `baz/foo.md`, then the first will have `bar/` as its unique prefix and the second one will have `baz/`.
+
+### pick_letter: char
+
+The letter that is displayed when picking a buffer to either focus or close it.
+
+### devicon
+
+This needs the `kyazdani42/nvim-web-devicons` plugin to be installed.
+The color is in hex format.
+
+#### devicon.icon: string
+
+An icon representing the buffer's filetype.
+
+#### devicon.color = '#rrggbb',
+
+The colors of the devicon in hexadecimal format (useful to be passed to a component's `fg` field (see the `Components` section).
+
+### diagnostics
+
+* diagnostics.errors: integer
+* diagnostics.warnings: integer
+* diagnostics.infos: integer
+* diagnostics.hints: integer
+
+The values in this table are the ones reported by Neovim's built in LSP interface. 
+
+## Methods
+
+```lua
+---@param self Buffer
+---Deletes the buffer
+function Buffer:delete()
+
+---@param self Buffer
+---Focuses the buffer
+function Buffer:focus()
+
+---@param self Buffer
+---@return number
+---Returns the number of lines in the buffer
+function Buffer:lines()
+
+---@param self Buffer
+---@return string[]
+---Returns the buffer's lines
+function Buffer:text()
+
+---@param buf Buffer
+---@return boolean
+---Returns true if the buffer is valid
+function Buffer:is_valid()
+```

--- a/lua/plugins/nvim-cokeline/WIKIS/Component.md
+++ b/lua/plugins/nvim-cokeline/WIKIS/Component.md
@@ -1,0 +1,91 @@
+# Component<Cx>
+
+You can configure what each buffer in your bufferline will be composed of by passing a list of components to the setup function.
+
+Components have the following structure:
+
+```lua
+Component = {
+  text = string | function(Cx) -> string,
+
+  fg = "#rrggbb" | "HlGroup" | function(cx: Cx) -> "#rrggbb" | "HlGroup",
+  bg = "#rrggbb" | "HlGroup" | function(cx: Cx) -> "#rrggbb" | "HlGroup",
+  style = "attr1,attr2,..." | function(cx: Cx) -> "attr1,attr2,...",
+
+  highlight = nil | "#rrggbb" | "HlGroup" | function(cx: Cx) -> "#rrggbb" | "HlGroup",
+
+  delete_buffer_on_left_click = boolean,
+
+  on_click = nil | function(id, clicks, buttons, modifiers, cx)
+
+  on_mouse_enter = nil | function(cx, mouse_col)
+
+  on_mouse_leave = nil | function(cx)
+
+  truncation = {
+    priority = integer,
+    direction = "left" | "middle" | "right",
+  },
+}
+```
+
+Depending on the location of the component Cx is a Buffer or TabPage object, or in the case of `rhs` components, just a table with an `is_hovered property`.
+
+For example, let's imagine we want to construct a very minimal bufferline where the only things we're displaying for each buffer are its index, its filename and a close button.
+
+Then in our setup function we'd have:
+
+```lua
+require('cokeline').setup({
+  -- ...
+
+  components = {
+    {
+      text = function(buffer) return ' ' .. buffer.index end,
+    },
+    {
+      text = function(buffer) return ' ' .. buffer.filename .. ' ' end,
+    },
+    {
+      text = '',
+      delete_buffer_on_left_click = true,
+    },
+    {
+      text = ' ',
+    }
+  }
+}
+```
+
+in this case every buffer would be composed of four components: the first displaying a space followed by the buffer index, the second one the filename padded by a space on each side, then a close button that allows us to :bdelete the buffer by left-clicking on it, and finally an extra space.
+
+This way of dividing each buffer into distinct components, combined with the ability to define every component's text and color depending on some property of the buffer we're rendering, allows for great customizability.
+
+the `text` key is the only one that has to be set, all the others are optional
+and can be omitted.
+
+The `truncation` table controls what happens when a buffer is too long to be
+displayed in its entirety.
+
+More specifically, if a buffer's width (given by the sum of the widths of all
+its components) is bigger than the `rendering.max_buffer_width` config option,
+the buffer will be truncated.
+
+The default behaviour is truncate the buffer by dropping components from right
+to left, with the text of the last component that's included also being
+shortened from right to left. This can be modified by changing the values of
+the `truncation.priority` and `truncation.direction` keys.
+
+The `truncation.priority` controls the order in which components are dropped:
+the first component to be dropped will be the one with the lowest priority. If
+that's still not enough to bring the width of the buffer within the
+`rendering.max_buffer_width` limit, the component with the second lowest
+priority will be dropped, and so on. Note that a higher priority means a
+smaller integer value: a component with a priority of 5 will be dropped
+_after_ a component with a priority of 6, even though 6 > 5.
+
+The `truncation.direction` key simply controls from which direction a component
+is shortened. For example, you might want to set the `truncation.direction` of
+a component displaying a filename to `'middle'` or `'left'`, so that if
+the filename has to be shortened you'll still be able to see its extension,
+like in the following example (where it's set to `'left'`):

--- a/lua/plugins/nvim-cokeline/WIKIS/Example-Configs.md
+++ b/lua/plugins/nvim-cokeline/WIKIS/Example-Configs.md
@@ -1,0 +1,685 @@
+# Example configs
+
+### author: [@noib3](https://github.com/noib3/)
+
+![userconfig-noib3](https://user-images.githubusercontent.com/38540736/226447816-c696153f-ccee-4e4a-8b6a-55e53ee737f8.png)
+
+<details>
+<summary>Click to see configuration</summary>
+
+```lua
+local get_hex = require('cokeline/utils').get_hex
+local mappings = require('cokeline/mappings')
+local comments_fg = get_hex('Comment', 'fg')
+local errors_fg = get_hex('DiagnosticError', 'fg')
+local warnings_fg = get_hex('DiagnosticWarn', 'fg')
+local red = vim.g.terminal_color_1
+local yellow = vim.g.terminal_color_3
+local components = {
+  space = {
+    text = ' ',
+    truncation = { priority = 1 }
+  },
+  two_spaces = {
+    text = '  ',
+    truncation = { priority = 1 },
+  },
+  separator = {
+    text = function(buffer)
+      return buffer.index ~= 1 and '▏' or ''
+    end,
+    truncation = { priority = 1 }
+  },
+  devicon = {
+    text = function(buffer)
+      return
+        (mappings.is_picking_focus() or mappings.is_picking_close())
+          and buffer.pick_letter .. ' '
+           or buffer.devicon.icon
+    end,
+    fg = function(buffer)
+      return
+        (mappings.is_picking_focus() and yellow)
+        or (mappings.is_picking_close() and red)
+        or buffer.devicon.color
+    end,
+    style = function(_)
+      return
+        (mappings.is_picking_focus() or mappings.is_picking_close())
+        and 'italic,bold'
+         or nil
+    end,
+    truncation = { priority = 1 }
+  },
+  index = {
+    text = function(buffer)
+      return buffer.index .. ': '
+    end,
+    truncation = { priority = 1 }
+  },
+  unique_prefix = {
+    text = function(buffer)
+      return buffer.unique_prefix
+    end,
+    fg = comments_fg,
+    style = 'italic',
+    truncation = {
+      priority = 3,
+      direction = 'left',
+    },
+  },
+  filename = {
+    text = function(buffer)
+      return buffer.filename
+    end,
+    style = function(buffer)
+      return
+        ((buffer.is_focused and buffer.diagnostics.errors ~= 0)
+          and 'bold,underline')
+        or (buffer.is_focused and 'bold')
+        or (buffer.diagnostics.errors ~= 0 and 'underline')
+        or nil
+    end,
+    truncation = {
+      priority = 2,
+      direction = 'left',
+    },
+  },
+  diagnostics = {
+    text = function(buffer)
+      return
+        (buffer.diagnostics.errors ~= 0 and '  ' .. buffer.diagnostics.errors)
+        or (buffer.diagnostics.warnings ~= 0 and '  ' .. buffer.diagnostics.warnings)
+        or ''
+    end,
+    fg = function(buffer)
+      return
+        (buffer.diagnostics.errors ~= 0 and errors_fg)
+        or (buffer.diagnostics.warnings ~= 0 and warnings_fg)
+        or nil
+    end,
+    truncation = { priority = 1 },
+  },
+  close_or_unsaved = {
+    text = function(buffer)
+      return buffer.is_modified and '●' or ''
+    end,
+    fg = function(buffer)
+      return buffer.is_modified and green or nil
+    end,
+    delete_buffer_on_left_click = true,
+    truncation = { priority = 1 },
+  },
+}
+require('cokeline').setup({
+  show_if_buffers_are_at_least = 2,
+  buffers = {
+    -- filter_valid = function(buffer) return buffer.type ~= 'terminal' end,
+    -- filter_visible = function(buffer) return buffer.type ~= 'terminal' end,
+    new_buffers_position = 'next',
+  },
+  rendering = {
+    max_buffer_width = 30,
+  },
+  default_hl = {
+    fg = function(buffer)
+      return
+        buffer.is_focused
+        and get_hex('Normal', 'fg')
+         or get_hex('Comment', 'fg')
+    end,
+    bg = get_hex('ColorColumn', 'bg'),
+  },
+  components = {
+    components.space,
+    components.separator,
+    components.space,
+    components.devicon,
+    components.space,
+    components.index,
+    components.unique_prefix,
+    components.filename,
+    components.diagnostics,
+    components.two_spaces,
+    components.close_or_unsaved,
+    components.space,
+  },
+})
+```
+
+</details>
+
+### author: [@jqhr](https://github.com/jqhr/)
+
+![userconfig-jqhr](https://user-images.githubusercontent.com/23305067/167068447-4235b889-510d-41f5-9ee0-f3490ae129dc.gif)
+
+<details>
+<summary>Click to see configuration</summary>
+
+```lua
+
+local map = vim.api.nvim_set_keymap
+local get_hex = require('cokeline/utils').get_hex
+local get_visible = require('cokeline/buffers').get_visible
+local is_picking_focus = require('cokeline/mappings').is_picking_focus
+local is_picking_close = require('cokeline/mappings').is_picking_close
+
+local red = vim.g.terminal_color_1
+local yellow = vim.g.terminal_color_3
+local oceanblue = '#0066cc'
+
+require('cokeline').setup({
+  -- Only show the bufferline when there are at least this many visible buffers.
+  -- default: `1`.
+  show_if_buffers_are_at_least = 1,
+
+  buffers = {
+    -- filter_valid = function(buffer) return buffer.filetype ~= 'netrw' and buffer.filetype ~= 'startify' end,
+
+    focus_on_delete = 'next',
+
+    new_buffers_position = 'next',
+  },
+
+  mappings = {
+    cycle_prev_next = true,
+  },
+
+  rendering = {
+    max_buffer_width = 999,
+  },
+
+  default_hl = {
+    fg = '#ffffff',
+    bg = function(buffer)
+      return
+        buffer.is_focused
+        and oceanblue
+        or get_hex('ColorColumn', 'bg')
+    end,
+  },
+  components = {
+    {
+      text = function(buffer)
+       return buffer.is_focused and '' or ' '
+      end ,
+      fg = function(buffer)
+        return buffer.is_focused and buffer.index ~= 1 and get_hex('Normal', 'bg') or oceanblue
+      end,
+      bg = function(buffer)
+        return buffer.is_focused and oceanblue or get_hex('Normal', 'bg')
+      end
+    },
+    {
+      text = function(buffer)
+        return
+          (is_picking_focus() or is_picking_close())
+          and buffer.pick_letter .. ' '
+           or buffer.devicon.icon
+      end,
+      fg = function(buffer)
+        return
+          (is_picking_focus() and red)
+          or (is_picking_close() and yellow)
+          or buffer.devicon.color
+      end,
+      style = function(_)
+        return
+          (is_picking_focus() or is_picking_close())
+          and 'italic,bold'
+           or nil
+      end,
+    },
+    {
+      text = function(buffer) return buffer.index .. ' ' end,
+      style = 'italic',
+    },
+    {
+      text = function(buffer) return buffer.filename .. '  ' end,
+      style = function(buffer) return buffer.is_focused and 'bold' or nil end,
+    },
+    {
+      text = function(buffer)
+        if buffer.is_focused then
+          return ''
+        end
+       local buffers = get_visible()
+       local next = buffer.index + 1
+       return buffers[next] and buffers[next].is_focused and '' or ' '
+      end ,
+      fg = function(buffer)
+        return buffer.is_focused and oceanblue or get_hex('Normal', 'fg')
+      end,
+      bg = get_hex('ColorColumn', 'bg')
+    },
+  },
+})
+
+```
+
+</details>
+
+
+
+
+![userconfig-noib3](https://user-images.githubusercontent.com/38540736/226447811-c35d930a-94d4-4715-889b-2b2e2fafe4bd.png)
+
+### author: [@olimorris](https://github.com/olimorris/dotfiles)
+
+<details>
+<summary>Click to see configuration</summary>
+
+```lua
+local M = {}
+
+function M.setup()
+  local present, cokeline = pcall(require, "cokeline")
+  if not present then
+    return
+  end
+
+  local colors = require("colors").get()
+
+  cokeline.setup({
+
+    show_if_buffers_are_at_least = 2,
+
+    mappings = {
+      cycle_prev_next = true,
+    },
+
+    default_hl = {
+      fg = function(buffer)
+        return buffer.is_focused and colors.purple or colors.gray
+      end,
+      bg = "NONE",
+      style = function(buffer)
+        return buffer.is_focused and "bold" or nil
+      end,
+    },
+
+    components = {
+      {
+        text = function(buffer)
+          return buffer.index ~= 1 and "  "
+        end,
+      },
+      {
+        text = function(buffer)
+          return buffer.index .. ": "
+        end,
+        style = function(buffer)
+          return buffer.is_focused and "bold" or nil
+        end,
+      },
+      {
+        text = function(buffer)
+          return buffer.unique_prefix
+        end,
+        fg = function(buffer)
+          return buffer.is_focused and colors.purple or colors.gray
+        end,
+        style = "italic",
+      },
+      {
+        text = function(buffer)
+          return buffer.filename .. " "
+        end,
+        style = function(buffer)
+          return buffer.is_focused and "bold" or nil
+        end,
+      },
+      {
+        text = function(buffer)
+          return buffer.is_modified and " ●"
+        end,
+        fg = function(buffer)
+          return buffer.is_focused and colors.red
+        end,
+      },
+      {
+        text = "  ",
+      },
+    },
+  })
+end
+
+return M
+```
+
+</details>
+
+![userconfig-olimorris](https://user-images.githubusercontent.com/38540736/226447827-e2dc7705-b255-4108-9b1a-037adb64c71c.gif)
+
+### author: [@alex-popov-tech](https://github.com/alex-popov-tech/.dotfiles)
+
+<details>
+<summary>Click to see configuration</summary>
+
+```lua
+return function()
+    local get_hex = require("cokeline/utils").get_hex
+    local space = {text = " "}
+    require("cokeline").setup(
+        {
+            mappings = {
+              cycle_prev_next = true,
+            },
+            default_hl = {
+              fg = function(buffer)
+                return
+                  buffer.is_focused and nil or get_hex("Comment", "fg")
+              end,
+              bg = "none",
+            },
+            components = {
+                space,
+                {
+                    text = function(buffer)
+                        return buffer.devicon.icon
+                    end,
+                    fg = function(buffer)
+                        return buffer.devicon.color
+                    end
+                },
+                {
+                    text = function(buffer)
+                        return buffer.filename
+                    end,
+                    fg = function(buffer)
+                        if buffer.is_focused then
+                            return "#78dce8"
+                        end
+                        if buffer.is_modified then
+                            return "#e5c463"
+                        end
+                        if buffer.lsp.errors ~= 0 then
+                            return "#fc5d7c"
+                        end
+                    end,
+                    style = function(buffer)
+                        if buffer.is_focused then
+                            return "underline"
+                        end
+                        return nil
+                    end
+                },
+                {
+                    text = function(buffer)
+                        if buffer.is_readonly then
+                            return " 🔒"
+                        end
+                        return ""
+                    end
+                },
+                space
+            }
+        }
+    )
+end
+```
+
+</details>
+
+![userconfig-alex-popov-tech](https://user-images.githubusercontent.com/38540736/226447825-7f314e18-472e-4148-982b-d569b1743a9b.png)
+
+### author: [@danielnieto](https://github.com/danielnieto)
+
+<details>
+<summary>This configuration shows Powerline styled tabline, and the basic stuff: just the devicons and the filename with unique prefixes. It also shows the pick buffer character.</summary>
+
+```lua
+local is_picking_focus = require("cokeline/mappings").is_picking_focus
+local is_picking_close = require("cokeline/mappings").is_picking_close
+local get_hex = require("cokeline/utils").get_hex
+
+local red = vim.g.terminal_color_1
+local yellow = vim.g.terminal_color_4
+local space = {text = " "}
+local dark = get_hex("Normal", "bg")
+local text = get_hex("Comment", "fg")
+local grey = get_hex("ColorColumn", "bg")
+local light = get_hex("Comment", "fg")
+local high = "#a6d120"
+
+require("cokeline").setup(
+    {
+        default_hl = {
+            fg = function(buffer)
+                if buffer.is_focused then
+                    return dark
+                end
+                return text
+            end,
+            bg = function(buffer)
+                if buffer.is_focused then
+                    return high
+                end
+                return grey
+            end
+        },
+        components = {
+            {
+                text = function(buffer)
+                    if buffer.index ~= 1 then
+                        return ""
+                    end
+                    return ""
+                end,
+                bg = function(buffer)
+                    if buffer.is_focused then
+                        return high
+                    end
+                    return grey
+                end,
+                fg = dark
+            },
+            space,
+            {
+                text = function(buffer)
+                    if is_picking_focus() or is_picking_close() then
+                        return buffer.pick_letter .. " "
+                    end
+
+                    return buffer.devicon.icon
+                end,
+                fg = function(buffer)
+                    if is_picking_focus() then
+                        return yellow
+                    end
+                    if is_picking_close() then
+                        return red
+                    end
+
+                    if buffer.is_focused then
+                        return dark
+                    else
+                        return light
+                    end
+                end,
+                style = function(_)
+                    return (is_picking_focus() or is_picking_close()) and "italic,bold" or nil
+                end
+            },
+            {
+                text = function(buffer)
+                    return buffer.unique_prefix .. buffer.filename .. "⠀"
+                end,
+                style = function(buffer)
+                    return buffer.is_focused and "bold" or nil
+                end
+            },
+            {
+                text = "",
+                fg = function(buffer)
+                    if buffer.is_focused then
+                        return high
+                    end
+                    return grey
+                end,
+                bg = dark
+            }
+        }
+    }
+)
+```
+
+</details>
+
+![cokeline-danielnieto89](https://user-images.githubusercontent.com/2120107/171753414-9d81c866-7f99-48f8-b6ff-0c28e8883aaa.gif)
+
+### author: [@miversen33](https://github.com/miversen33)
+
+<details>
+<summary>This configuration shows the `is_first` and `is_last` buffer options and how to create a cokeline with different components based on if the
+component is the first, last, or neither Additionally, this config has some integration with the lsp.</summary>
+
+```lua
+local get_hex = require("cokeline.utils").get_hex
+local active_bg_color = '#931E9E'
+local inactive_bg_color = get_hex('Normal', 'bg')
+local bg_color = get_hex('ColorColumn', 'bg')
+require('cokeline').setup({
+      show_if_buffers_are_at_least = 1,
+      mappings = {
+          cycle_prev_next = true
+      },
+      default_hl = {
+        bg = function(buffer)
+          if buffer.is_focused then
+            return active_bg_color
+          end
+        end,
+      },
+      components = {
+          {
+            text = function(buffer)
+              local _text = ''
+              if buffer.index > 1 then _text = ' ' end
+              if buffer.is_focused or buffer.is_first then
+                _text = _text .. ''
+              end
+              return _text
+            end,
+            fg = function(buffer)
+              if buffer.is_focused then
+                return active_bg_color
+              elseif buffer.is_first then
+                return inactive_bg_color
+              end
+            end,
+            bg = function(buffer)
+              if buffer.is_focused then
+                if buffer.is_first then
+                  return bg_color
+                else
+                  return inactive_bg_color
+                end
+              elseif buffer.is_first then
+                  return bg_color
+              end
+            end
+          },
+          {
+              text = function(buffer)
+                  local status = ''
+                  if buffer.is_readonly then
+                      status = '➖'
+                  elseif buffer.is_modified then
+                      status = ''
+                  end
+                  return status
+              end,
+          },
+          {
+              text = function(buffer)
+                  return " " .. buffer.devicon.icon
+              end,
+              fg = function(buffer)
+                if buffer.is_focused then
+                  return buffer.devicon.color
+                end
+              end
+          },
+          {
+              text = function(buffer)
+                return buffer.unique_prefix .. buffer.filename
+              end,
+              fg = function(buffer)
+                  if(buffer.diagnostics.errors > 0) then
+                      return '#C95157'
+                  end
+              end,
+              style = function(buffer)
+                  local text_style = 'NONE'
+                  if buffer.is_focused then
+                      text_style = 'bold'
+                  end
+                  if buffer.diagnostics.errors > 0 then
+                      if text_style ~= 'NONE' then
+                          text_style = text_style .. ',underline'
+                      else
+                          text_style = 'underline'
+                      end
+                  end
+                  return text_style
+              end
+          },
+          {
+              text = function(buffer)
+                  local errors = buffer.diagnostics.errors
+                  if(errors <= 9) then
+                      errors = ''
+                  else
+                      errors = "🙃"
+                  end
+                  return errors .. ' '
+              end,
+              fg = function(buffer)
+                if buffer.diagnostics.errors == 0 then
+                  return '#3DEB63'
+                elseif buffer.diagnostics.errors <= 9 then
+                  return '#DB121B'
+                end
+              end
+          },
+          {
+              text = '',
+              delete_buffer_on_left_click = true
+          },
+          {
+            text = function(buffer)
+              if buffer.is_focused or buffer.is_last then
+                return ''
+              else
+                return ' '
+              end
+            end,
+            fg = function(buffer)
+              if buffer.is_focused then
+                return active_bg_color
+              elseif buffer.is_last then
+                return inactive_bg_color
+              else
+                return bg_color
+              end
+            end,
+            bg = function(buffer)
+              if buffer.is_focused then
+                if buffer.is_last then
+                  return bg_color
+                else
+                  return inactive_bg_color
+                end
+              elseif buffer.is_last then
+                  return bg_color
+              end
+            end
+          }
+      },
+  })
+```
+
+</details>
+
+![cokeline-miversen33](https://user-images.githubusercontent.com/2640668/174489433-2faa0eea-4921-42ea-a877-1e143e44bc14.png)

--- a/lua/plugins/nvim-cokeline/WIKIS/History.md
+++ b/lua/plugins/nvim-cokeline/WIKIS/History.md
@@ -1,0 +1,51 @@
+# History
+
+The History keeps track of the buffers you access using a ringbuffer, and provides an API for accessing Buffer objects from the history.
+
+You can access the history using `require("cokeline.history")`, or through the global `_G.cokeline.history`.
+
+The History object provides these methods:
+
+```lua
+---Adds a Buffer object to the history
+function History:push(bufnr: int)
+end
+
+---Removes and returns the oldest Buffer object in the history
+function History:pop(): Buffer | nil
+end
+
+---Returns a list of Buffer objects in the history,
+---ordered from oldest to newest
+function History:list(): Buffer[]
+end
+
+---Returns an iterator of Buffer objects in the history,
+---ordered from oldest to newest
+function History:iter(): fun(): Buffer | nil
+end
+
+---Get a Buffer object by history index
+function History:get(idx: int): Buffer | nil
+end
+
+---Get a Buffer object representing the last-accessed buffer (before the current one)
+function History:last(): Buffer | nil
+end
+
+---Returns true if the history is empty
+function History:is_empty(): boolean
+end
+
+---Returns the maximum number of buffers that can be stored in the history
+function History:capacity(): int
+end
+
+---Returns true if the history contains the given buffer
+function History:contains(bufnr: int): bool
+end
+
+---Returns the number of buffers in the history
+function History:len(): int
+end
+```

--- a/lua/plugins/nvim-cokeline/WIKIS/Home.md
+++ b/lua/plugins/nvim-cokeline/WIKIS/Home.md
@@ -1,0 +1,354 @@
+Welcome to the nvim-cokeline wiki!
+
+
+## Configuration recipes
+
+### Harpoon-based sorting:
+
+This sorter pins harpoon-marked buffers to the left hand side of the tabline, while still allowing you to rearrange any others that are open. Any harpoon mark order changes will be reflected immediately in the tabline.
+
+> [!NOTE]
+> This sorter only work with Harpoon v2; It also may not be up to date. If you notice that it is broken or outdated, contributions are welcome :)
+
+```lua
+local function harpoon_sorter()
+  local cache = {}
+  local setup = false
+
+  local function marknum(buf, force)
+    local harpoon = require("harpoon")
+    local b = cache[buf.number]
+    if b == nil or force then
+      local path =
+        require("plenary.path"):new(buf.path):make_relative(vim.uv.cwd())
+      for i, mark in ipairs(harpoon:list():display()) do
+        if mark == path then
+          b = i
+          cache[buf.number] = b
+          break
+        end
+      end
+    end
+    return b
+  end
+
+  -- Use this in `config.buffers.new_buffers_position`
+  return function(a, b)
+    -- Only run this if harpoon is loaded, otherwise just use the default sorting.
+    -- This could be used to only run if a user has harpoon installed, but
+    -- I'm mainly using it to avoid loading harpoon on UiEnter.
+    local has_harpoon = package.loaded["harpoon"] ~= nil
+    if not has_harpoon then
+      ---@diagnostic disable-next-line: undefined-field
+      return a._valid_index < b._valid_index
+    elseif not setup then
+      local refresh = function()
+        cache = {}
+      end
+      require("harpoon"):extend({
+        ADD = refresh,
+        REMOVE = refresh,
+        REORDER = refresh,
+        LIST_CHANGE = refresh,
+      })
+      setup = true
+    end
+    -- switch the a and b._valid_index to place non-harpoon buffers on the left
+    -- side of the tabline - this puts them on the right.
+    local ma = marknum(a)
+    local mb = marknum(b)
+    if ma and not mb then
+      return true
+    elseif mb and not ma then
+      return false
+    elseif ma == nil and mb == nil then
+      ma = a._valid_index
+      mb = b._valid_index
+    end
+    return ma < mb
+  end
+end
+```
+
+### Focus mappings by @psmolak:
+
+<details>
+
+<summary>From <a href="https://github.com/willothy/nvim-cokeline/issues/59">#59</a></summary>
+
+Instead of setting up new keybinding for each buffer number separately in a loop, we could use `count` variable like so:
+
+ ```lua
+ vim.keymap.set('n', '<tab>', function()
+   return ('<Plug>(cokeline-focus-%s)'):format(vim.v.count > 0 and vim.v.count or 'next')
+ end, { silent = true, expr = true })
+ ```
+
+Now whenever we precede `Tab` with a count, we will go directly to that buffer. Otherwise the `Tab` will just move to the next buffer in a list.
+
+</details>
+
+### Rounded corners
+
+![userconfig-noib3](https://user-images.githubusercontent.com/38540736/226447796-12200cca-9dec-4145-8f4a-d271512bdf8c.png)
+
+<details>
+<summary>This config shows how you configure buffers w/ rounded corners.</summary>
+
+```lua
+local hlgroups = require('cokeline.hlgroups')
+local hl_attr = hlgroups.get_hl_attr
+
+require('cokeline').setup({
+  default_hl = {
+    fg = function(buffer)
+      return
+        buffer.is_focused
+        and hl_attr('Normal', 'fg')
+         or hl_attr('Comment', 'fg')
+    end,
+    bg = hl_attr('ColorColumn', 'bg'),
+  },
+
+  components = {
+    {
+      text = ' ',
+      bg = hl_attr('Normal', 'bg'),
+    },
+    {
+      text = '',
+      fg = hl_attr('ColorColumn', 'bg'),
+      bg = hl_attr('Normal', 'bg'),
+    },
+    {
+      text = function(buffer)
+        return buffer.devicon.icon
+      end,
+      fg = function(buffer)
+        return buffer.devicon.color
+      end,
+    },
+    {
+      text = ' ',
+    },
+    {
+      text = function(buffer) return buffer.filename .. '  ' end,
+      style = function(buffer)
+        return buffer.is_focused and 'bold' or nil
+      end,
+    },
+    {
+      text = '',
+      delete_buffer_on_left_click = true,
+    },
+    {
+      text = '',
+      fg = hl_attr('ColorColumn', 'bg'),
+      bg = hl_attr('Normal', 'bg'),
+    },
+  },
+})
+```
+
+</details>
+
+### Equally sized buffers
+
+<details>
+<summary>
+This config shows how to get equally sized buffers. All the buffers
+are 23 characters wide, adding padding spaces left and right if a buffer is too
+short and cutting it off if it's too long.
+</summary>
+
+```lua
+local hl_attr = require('cokeline.hlgroups').get_hl_attr
+local mappings = require('cokeline.mappings')
+
+local str_rep = string.rep
+
+local green = vim.g.terminal_color_2
+local yellow = vim.g.terminal_color_3
+
+local comments_fg = hl_attr('Comment', 'fg')
+local errors_fg = hl_attr('DiagnosticError', 'fg')
+local warnings_fg = hl_attr('DiagnosticWarn', 'fg')
+
+local min_buffer_width = 23
+
+local components = {
+  separator = {
+    text = ' ',
+    bg = hl_attr('Normal', 'bg'),
+    truncation = { priority = 1 },
+  },
+
+  space = {
+    text = ' ',
+    truncation = { priority = 1 },
+  },
+
+  left_half_circle = {
+    text = '',
+    fg = hl_attr('ColorColumn', 'bg'),
+    bg = hl_attr('Normal', 'bg'),
+    truncation = { priority = 1 },
+  },
+
+  right_half_circle = {
+    text = '',
+    fg = hl_attr('ColorColumn', 'bg'),
+    bg = hl_attr('Normal', 'bg'),
+    truncation = { priority = 1 },
+  },
+
+  devicon = {
+    text = function(buffer)
+      return buffer.devicon.icon
+    end,
+    fg = function(buffer)
+      return buffer.devicon.color
+    end,
+    truncation = { priority = 1 },
+  },
+
+  index = {
+    text = function(buffer)
+      return buffer.index .. ': '
+    end,
+    fg = function(buffer)
+      return
+        (buffer.diagnostics.errors ~= 0 and errors_fg)
+        or (buffer.diagnostics.warnings ~= 0 and warnings_fg)
+        or nil
+    end,
+    truncation = { priority = 1 },
+  },
+
+  unique_prefix = {
+    text = function(buffer)
+      return buffer.unique_prefix
+    end,
+    fg = comments_fg,
+    style = 'italic',
+    truncation = {
+      priority = 3,
+      direction = 'left',
+    },
+  },
+
+  filename = {
+    text = function(buffer)
+      return buffer.filename
+    end,
+    fg = function(buffer)
+      return
+        (buffer.diagnostics.errors ~= 0 and errors_fg)
+        or (buffer.diagnostics.warnings ~= 0 and warnings_fg)
+        or nil
+    end,
+    style = function(buffer)
+      return
+        ((buffer.is_focused and buffer.diagnostics.errors ~= 0)
+          and 'bold,underline')
+        or (buffer.is_focused and 'bold')
+        or (buffer.diagnostics.errors ~= 0 and 'underline')
+        or nil
+    end
+    truncation = {
+      priority = 2,
+      direction = 'left',
+    },
+  },
+
+  close_or_unsaved = {
+    text = function(buffer)
+      return buffer.is_modified and '●' or ''
+    end,
+    fg = function(buffer)
+      return buffer.is_modified and green or nil
+    end
+    delete_buffer_on_left_click = true,
+    truncation = { priority = 1 },
+  },
+}
+
+local get_remaining_space = function(buffer)
+  local used_space = 0
+  for _, component in pairs(components) do
+    used_space = used_space + vim.fn.strwidth(
+      (type(component.text) == 'string' and component.text)
+      or (type(component.text) == 'function' and component.text(buffer))
+    )
+  end
+  return math.max(0, min_buffer_width - used_space)
+end
+
+local left_padding = {
+  text = function(buffer)
+    local remaining_space = get_remaining_space(buffer)
+    return str_rep(' ', remaining_space / 2 + remaining_space % 2)
+  end,
+}
+
+local right_padding = {
+  text = function(buffer)
+    local remaining_space = get_remaining_space(buffer)
+    return str_rep(' ', remaining_space / 2)
+  end,
+}
+
+require('cokeline').setup({
+  show_if_buffers_are_at_least = 2,
+
+  buffers = {
+    -- filter_valid = function(buffer) return buffer.type ~= 'terminal' end,
+    -- filter_visible = function(buffer) return buffer.type ~= 'terminal' end,
+    focus_on_delete = 'next',
+    new_buffers_position = 'next',
+  },
+
+  rendering = {
+    max_buffer_width = 23,
+  },
+
+  default_hl = {
+    fg = function(buffer)
+      return
+        buffer.is_focused
+        and hl_attr('Normal', 'fg')
+         or hl_attr('Comment', 'fg')
+    end,
+    bg = hl_attr('ColorColumn', 'bg'),
+  },
+
+  sidebar = {
+    filetype = 'NvimTree',
+    components = {
+      {
+        text = '  NvimTree',
+        fg = yellow,
+        bg = hl_attr('NvimTreeNormal', 'bg'),
+        style = 'bold',
+      },
+    }
+  },
+
+  components = {
+    components.separator,
+    components.left_half_circle,
+    left_padding,
+    components.devicon,
+    components.index,
+    components.unique_prefix,
+    components.filename,
+    components.space,
+    right_padding,
+    components.close_or_unsaved,
+    components.right_half_circle,
+  },
+})
+
+```
+
+</details>

--- a/lua/plugins/nvim-cokeline/WIKIS/TabPage.md
+++ b/lua/plugins/nvim-cokeline/WIKIS/TabPage.md
@@ -1,0 +1,55 @@
+# TabPage
+
+Some of the configuration options can be functions that take a `TabPage` as a
+single parameter. This is useful as it allows users to set the values of
+components dynamically based on the buffer that component is being rendered
+for.
+
+```lua
+TabPage = {
+  number = integer,
+  windows = Window[],
+  focused = Window,
+  is_active = boolean,
+  is_first = boolean,
+  is_last = boolean
+}
+```
+
+## Properties
+
+### number: integer
+
+The tabpage number
+
+### windows: Window[]
+
+The Window objects representing the tabpage's windows.
+
+### focused: Window
+
+The currently focused window in the tabpage
+
+### is_active: boolean
+
+Whether the tabpage is the current tabpage
+
+### is_first: boolean
+
+Whether the tabpage is first in the list of tabpages (the smallest tabnr returned from `vim.api.nvim_list_tabpages()`).
+
+### is_last: boolean
+
+Whether the tabpage is last in the list of tabpages (the largest tabnr returned from `vim.api.nvim_list_tabpages()`).
+
+## Methods
+
+### TabPage:focus()
+
+Focuses the tabpage. Equivalent to `vim.api.nvim_set_current_tabpage(TabPage.number)`.
+
+### TabPage:close()
+
+Closes the tabpage, as long as it is not the last one open.
+
+

--- a/lua/plugins/nvim-cokeline/WIKIS/Window.md
+++ b/lua/plugins/nvim-cokeline/WIKIS/Window.md
@@ -1,0 +1,30 @@
+# Window
+
+Tabpage objects contain window objects. The window object is simply a lua table with the following values:
+
+```lua
+Window = {
+  number = integer,
+  buffer = Buffer
+}
+```
+
+## Properties
+
+### number: integer
+
+The window's internal id number, as reported by `vim.api.nvim_get_current_win()`.
+
+### buffer: Buffer
+
+The Buffer object representing the buffer that is shown in the window.
+
+## Methods
+
+```lua
+--- Closes the window
+function Window:close()
+
+--- Focuses the window
+function Window:focus()
+```

--- a/lua/plugins/nvim-cokeline/WIKIS/_Sidebar.md
+++ b/lua/plugins/nvim-cokeline/WIKIS/_Sidebar.md
@@ -1,0 +1,80 @@
+# API Reference
+
+## Objects
+
+* [Component](https://github.com/willothy/nvim-cokeline/wiki/Component)
+* [Buffer](https://github.com/willothy/nvim-cokeline/wiki/Buffer)
+* [TabPage](https://github.com/willothy/nvim-cokeline/wiki/TabPage)
+* [Window](https://github.com/willothy/nvim-cokeline/wiki/Window)
+* [History](https://github.com/willothy/nvim-cokeline/wiki/History)
+
+## Functions
+
+### cokeline.mappings
+
+* [pick(goal)](https://github.com/willothy/nvim-cokeline/wiki)
+  Focus or close a buffer using pick letters.
+* [by_step(goal, step)](https://github.com/willothy/nvim-cokeline/wiki)
+  Focus or close a buffer using a relative offset (-1, 1, etc.)
+* [by_index(goal, idx)](https://github.com/willothy/nvim-cokeline/wiki)
+  Focus or close a buffer by its index.
+
+### cokeline.utils
+
+* [buf_delete(bufnr, wipe)](https://github.com/willothy/nvim-cokeline/wiki)
+  Delete the given buffer while maintaining window layout.
+
+### cokeline.hlgroups
+
+* [get_hl(group_name)](https://github.com/willothy/nvim-cokeline/wiki)
+  Memoized wrapper around `nvim_get_hl`
+* [get_hl_attr(group_name, attr)](https://github.com/willothy/nvim-cokeline/wiki)
+  Get a single attribute from a hlgroup. Memoized with same cache as `get_hl`.
+
+### cokeline.buffers
+
+* [is_visible(bufnr)](https://github.com/willothy/nvim-cokeline/wiki)
+  Returns true if the buffer is visible.
+* [get_current()](https://github.com/willothy/nvim-cokeline/wiki)
+  Returns the Buffer object for the current buffer.
+* [get_buffer(bufnr)](https://github.com/willothy/nvim-cokeline/wiki)
+  Returns the Buffer object for the given bufnr, if valid.
+* [get_visible()](https://github.com/willothy/nvim-cokeline/wiki)
+  Returns a list of visible Buffer objects.
+* [get_valid_buffers()](https://github.com/willothy/nvim-cokeline/wiki)
+  Returns a list of valid buffers.
+* [move_buffer(buffer, target)](https://github.com/willothy/nvim-cokeline/wiki)
+  Move a buffer to a different position.
+* [release_taken_letter(bufnr)](https://github.com/willothy/nvim-cokeline/wiki)
+  Release the pick letter for a Buffer object.
+
+### cokeline.tabs
+
+* [update_current(tabnr)](https://github.com/willothy/nvim-cokeline/wiki)
+* [fetch_tabs()](https://github.com/willothy/nvim-cokeline/wiki)
+  Update the list of tabpges.
+* [get_tabs()](https://github.com/willothy/nvim-cokeline/wiki)
+  Returns a list of Tabpage objects.
+* [get_tabpage(tabnr)](https://github.com/willothy/nvim-cokeline/wiki)
+  Returns the Tabpage object for tabnr, if valid.
+
+### cokeline.history
+
+* [push(bufnr)](https://github.com/willothy/nvim-cokeline/wiki)
+  Push an item into the history.
+* [pop()](https://github.com/willothy/nvim-cokeline/wiki)
+  Pop the last item off of the history.
+* [list()](https://github.com/willothy/nvim-cokeline/wiki)
+  Returns the history items as a (copied) list.
+* [iter()](https://github.com/willothy/nvim-cokeline/wiki)
+  Returns an iterator over the history items.
+* [get(idx)](https://github.com/willothy/nvim-cokeline/wiki)
+  Get the item at history index `idx`, if any.
+* [last()](https://github.com/willothy/nvim-cokeline/wiki)
+  Peek the last item in the history, without removing it.
+* [contains(bufnr)](https://github.com/willothy/nvim-cokeline/wiki)
+  Check if the history contains the given `bufnr`.
+* [capacity()](https://github.com/willothy/nvim-cokeline/wiki)
+  Returns the configured capacity.
+* [len()](https://github.com/willothy/nvim-cokeline/wiki)
+  Returns the number of items in the history.

--- a/lua/plugins/nvim-cokeline/dependencies.lua
+++ b/lua/plugins/nvim-cokeline/dependencies.lua
@@ -1,0 +1,9 @@
+---@type LazySpec[]
+local dependencies = {
+  "nvim-tree/nvim-web-devicons",
+
+  -- optional: persistent buffer order across sessions
+  --"stevearc/resession.nvim",
+}
+
+return dependencies

--- a/lua/plugins/nvim-cokeline/events.lua
+++ b/lua/plugins/nvim-cokeline/events.lua
@@ -1,0 +1,6 @@
+---@type table
+local events = {
+  "VeryLazy",
+}
+
+return events

--- a/lua/plugins/nvim-cokeline/init.lua
+++ b/lua/plugins/nvim-cokeline/init.lua
@@ -1,0 +1,40 @@
+---@type LazySpec
+local spec = {
+  "willothy/nvim-cokeline",
+  --lazy = false,
+  --url = "",
+  --name = "",
+  --dev = false,
+  --dir = "",
+  --build = "",
+  --branch = "",
+  --tag = "",
+  --version = "",
+  --commit = "",
+  --main = "",
+  --pin = false,
+  --submodules = false,
+  --module = false,
+  --optional = false,
+  --ft = require("plugins.nvim-cokeline.ft"),
+  --cmd = require("plugins.nvim-cokeline.cmds"),
+  keys = require("plugins.nvim-cokeline.keys"),
+  event = require("plugins.nvim-cokeline.events"),
+  dependencies = require("plugins.nvim-cokeline.dependencies"),
+  init = function()
+    -- cokeline reads hex gui values, so truecolor is a hard requirement
+    vim.opt.termguicolors = true
+    -- cokeline sets this itself on load, but keep the requirement visible here
+    vim.opt.showtabline = 2
+  end,
+  --opts = require("plugins.nvim-cokeline.opts"),
+  config = function()
+    local opts = require("plugins.nvim-cokeline.opts")
+    require("cokeline").setup(opts)
+  end,
+  --priority = 1000,
+  --cond = false,
+  --enabled = false,
+}
+
+return spec

--- a/lua/plugins/nvim-cokeline/keys.lua
+++ b/lua/plugins/nvim-cokeline/keys.lua
@@ -1,0 +1,19 @@
+---@type LazyKeysSpec[]
+local keys = {
+  {
+    "<leader>bn",
+    "<Plug>(cokeline-focus-next)",
+    mode = "n",
+    desc = "Cokeline: focus next buffer",
+    silent = true,
+  },
+  {
+    "<leader>bp",
+    "<Plug>(cokeline-focus-prev)",
+    mode = "n",
+    desc = "Cokeline: focus prev buffer",
+    silent = true,
+  },
+}
+
+return keys

--- a/lua/plugins/nvim-cokeline/opts.lua
+++ b/lua/plugins/nvim-cokeline/opts.lua
@@ -1,0 +1,6 @@
+-- Intentionally empty: run on cokeline's defaults first, tune later.
+-- See CODES/lua/cokeline/config.lua for every available option.
+---@type table
+local opts = {}
+
+return opts

--- a/lua/plugins/nvim-cokeline/stylua.toml
+++ b/lua/plugins/nvim-cokeline/stylua.toml
@@ -1,0 +1,13 @@
+#syntax = "All"
+column_width = 120
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferDouble"
+call_parentheses = "Always"
+collapse_simple_statement = "Never"
+space_after_function_names = "Never"
+block_newline_gaps = "Never"
+
+[sort_requires]
+enabled = false


### PR DESCRIPTION
## 問題

バッファ行が無く、開いているバッファを一覧できない。

`add/*` ブランチには vendoring したまま spec が埋まっていないものが多数あり、
バッファ行についても `add/bufferline-nvim`（テンプレのまま）と
`add/barbar-nvim`（半端に埋まった状態）が残っている。
入れる前に設定を全部決めようとして着地しないのが原因。

## 解決

`nvim-cokeline` を **デフォルト設定のまま** 入れる。`opts.lua` は空テーブルにして、
見た目の調整は別途行う。

### プラグイン選定

| 候補 | 最終push | 判断 |
|---|---|---|
| **willothy/nvim-cokeline** | 2026-06-19 | **採用。** 現役メンテ。`setup()` だけでデフォルトが効く。コードベースが小さく後で読める |
| akinsho/bufferline.nvim | 2025-01-14 | 19ヶ月停止（v4.9.1 が最後、open issue 103） |
| romgrk/barbar.nvim | 2026-06-10 | 現役だが既存ブランチの状態が半端で、掃除の判断が先に来る |
| nvim-mini/mini.tabline | 2026-07-07 | 設定項目3つで最も安全だが、調整の余地を優先して不採用 |
| nanozuki/tabby.nvim | 2026-01-07 | tabpage 志向で用途が違う |

`add/bufferline-nvim` と `add/barbar-nvim` は本 PR では触っていない。

### 内容

- `init.lua` — `keys` / `event` / `dependencies` / `init` / `config` を有効化
  - `init` 内で `termguicolors = true` と `showtabline = 2` を明示。
    cokeline は後者を自分でも設定するが、`lua/config/options.lua` を
    書き換えても壊れないよう spec 側で自己完結させる
  - `lua/config/options.lua` は変更していない
- `dependencies.lua` — `nvim-tree/nvim-web-devicons`。
  `resession.nvim` はオプショナルなのでコメントで残置
- `opts.lua` — 空テーブル
- `keys.lua` — `<leader>bn` / `<leader>bp` → `<Plug>(cokeline-focus-next/prev)`。
  上流 README は `<Tab>` / `<S-Tab>` を推奨しているが、`<Tab>` は `<C-i>`
  （jumplist 前進）と同一キーなので採らない
- `cmds.lua` / `ft.lua` — cokeline はユーザーコマンドを定義せず filetype 制限も
  不要なため削除

## 検証

- 実 TUI セッションでタブライン描画を確認（3バッファがアイコン付きで並び、
  ハイライト群がバッファごとに別々に当たっている）
- 実キー入力で `<leader>bn` / `<leader>bp` の双方向移動を確認
- `stylua --check lua/plugins/nvim-cokeline/*.lua` — OK
- `task check-keys` — OK（50ファイル）
- `nvim --headless "+Lazy! install nvim-cokeline" "+Lazy! load nvim-cokeline" +qa` — エラーなし