### PR TITLE
docs(claude): split headless and neowright verification roles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,23 @@ Skills are located in `.claude/skills/kiro-*/SKILL.md`
 - Keep steering current and verify alignment with `/kiro-spec-status`
 - Follow the user's instructions precisely, and within that scope act autonomously: gather the necessary context and complete the requested work end-to-end in this run, asking questions only when essential information is missing or the instructions are critically ambiguous.
 
+## 動作確認の使い分け
+
+- **「読み込めるか」= headless。**
+  `nvim --headless "+Lazy! install <repo>" "+Lazy! load <repo>" +qa` は
+  spec が壊れていないことの確認まで。`add-plugin` skill が指定しているのもここまで。
+- **「動くか」= `neowright` skill。** UI 描画・キーマップ・タブライン・フロート窓・
+  補完メニューが絡む確認で headless を使わない。
+
+**Why**: headless は偽の失敗を出す。2026-08-02 の nvim-cokeline 導入時に実際に2つ踏んだ。
+
+- `nvim_replace_termcodes` は `<leader>` を展開しないので、`feedkeys` でマッピングに当たらない
+- 描画時に更新されるプラグイン内部状態（cokeline の可視バッファ一覧など）が
+  headless では構築されず、正常な機能が動かないように見える
+
+どちらもプラグインではなく検証環境の問題で、切り分けに往復を3回使った。
+neowright に切り替えたら1回で通った。**速いと思った手段のほうが遅かった。**
+
 ## Steering Configuration
 - Load entire `.kiro/steering/` as project memory
 - Default files: `product.md`, `tech.md`, `structure.md`


### PR DESCRIPTION
## 問題

このリポジトリで動作確認をするとき、headless の `nvim` と `neowright` skill の
使い分けが明文化されていない。

結果として、`add-plugin` skill が読み込み確認に指定している
`nvim --headless "+Lazy! install" "+Lazy! load" +qa` を、そのまま機能の動作確認にまで
拡大して使ってしまう。

## 実際に起きたこと

2026-08-02 の `nvim-cokeline` 導入（#250）で、headless が**偽の失敗**を2回出した。

1. `nvim_replace_termcodes` は `<leader>` を展開しないため、`nvim_feedkeys` で
   送ったキーがマッピングに当たらず「キーマップが効かない」と誤認した
2. cokeline の可視バッファ一覧は描画時に構築されるため、描画の無い headless では
   `by_step("focus", -1)` が動かず「片方向しか動かない」と誤認した

どちらもプラグイン側ではなく検証環境の問題。切り分けに往復を3回消費した。
`neowright` に切り替えたところ、実 TUI で描画・双方向のキー移動とも一度で確認できた。

## 解決

`CLAUDE.md` に使い分けと理由を書く。

- **「読み込めるか」= headless** — spec が壊れていないことの確認まで
- **「動くか」= `neowright` skill** — UI 描画・キーマップ・タブライン・フロート窓・
  補完メニューが絡む確認では headless を使わない

理由を併記しているのは、規則だけだと「速そうだから」で headless に戻るため。

## 備考

追記部分は日本語で書いた。既存の本文は英語のままだが、グローバルの言語ポリシーが
2026-08-01 に「CLAUDE.md の散文は日本語」へ変更されているため、新規の散文はそれに従った。
既存部分の翻訳は本 PR では行っていない。