### PR TITLE
docs(claude): translate CLAUDE.md to Japanese

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,61 +1,68 @@
-# Agentic SDLC and Spec-Driven Development
+# エージェント型 SDLC と仕様駆動開発
 
-Kiro-style Spec-Driven Development on an agentic SDLC
+エージェント型 SDLC 上で回す Kiro 方式の仕様駆動開発。
 
-## Project Context
+## プロジェクトの前提
 
-### Paths
-- Steering: `.kiro/steering/`
-- Specs: `.kiro/specs/`
+### パス
+- ステアリング: `.kiro/steering/`
+- 仕様: `.kiro/specs/`
 
-### Steering vs Specification
+### ステアリングと仕様の違い
 
-**Steering** (`.kiro/steering/`) - Guide AI with project-wide rules and context
-**Specs** (`.kiro/specs/`) - Formalize development process for individual features
+**ステアリング**（`.kiro/steering/`）— プロジェクト全体の規則と背景で AI を方向づける
+**仕様**（`.kiro/specs/`）— 個々の機能について開発プロセスを形式化する
 
-### Active Specifications
-- Check `.kiro/specs/` for active specifications
-- Use `/kiro-spec-status [feature-name]` to check progress
+### 進行中の仕様
+- 進行中の仕様は `.kiro/specs/` を見る
+- 進捗確認には `/kiro-spec-status [feature-name]` を使う
 
-## Development Guidelines
-- Think in English, generate responses in Japanese. All Markdown content written to project files (e.g., requirements.md, design.md, tasks.md, research.md, validation reports) MUST be written in the target language configured for this specification (see spec.json.language).
+## 開発ガイドライン
+- 思考は英語、応答は日本語で生成する。プロジェクトのファイルへ書き出す Markdown
+  （`requirements.md`、`design.md`、`tasks.md`、`research.md`、検証レポートなど）は、
+  その仕様に設定された対象言語で書くこと（`spec.json` の `language` を参照）。
 
-## Minimal Workflow
-- Phase 0 (optional): `/kiro-steering`, `/kiro-steering-custom`
-- Discovery: `/kiro-discovery "idea"` — determines action path, writes brief.md + roadmap.md for multi-spec projects
-- Phase 1 (Specification):
-  - Single spec: `/kiro-spec-quick {feature} [--auto]` or step by step:
+## 最小ワークフロー
+- フェーズ0（任意）: `/kiro-steering`、`/kiro-steering-custom`
+- ディスカバリ: `/kiro-discovery "idea"` — 進め方を判定し、複数仕様のプロジェクトなら
+  `brief.md` と `roadmap.md` を書き出す
+- フェーズ1（仕様策定）:
+  - 単一仕様: `/kiro-spec-quick {feature} [--auto]`、または段階的に:
     - `/kiro-spec-init "description"`
     - `/kiro-spec-requirements {feature}`
-    - `/kiro-validate-gap {feature}` (optional: for existing codebase)
+    - `/kiro-validate-gap {feature}`（任意: 既存コードベース向け）
     - `/kiro-spec-design {feature} [-y]`
-    - `/kiro-validate-design {feature}` (optional: design review)
+    - `/kiro-validate-design {feature}`（任意: 設計レビュー）
     - `/kiro-spec-tasks {feature} [-y]`
-  - Multi-spec: `/kiro-spec-batch` — creates all specs from roadmap.md in parallel by dependency wave
-- Phase 2 (Implementation): `/kiro-impl {feature} [tasks]`
-  - Without task numbers: autonomous mode (subagent per task + independent review + final validation)
-  - With task numbers: manual mode (selected tasks in main context, still reviewer-gated before completion)
-  - `/kiro-validate-impl {feature}` (standalone re-validation)
-- Progress check: `/kiro-spec-status {feature}` (use anytime)
+  - 複数仕様: `/kiro-spec-batch` — `roadmap.md` の全仕様を依存関係の波ごとに並列生成する
+- フェーズ2（実装）: `/kiro-impl {feature} [tasks]`
+  - タスク番号なし: 自律モード（タスクごとに subagent ＋ 独立レビュー ＋ 最終検証）
+  - タスク番号あり: 手動モード（選んだタスクをメインコンテキストで実行。
+    完了前にレビュアを通す点は同じ）
+  - `/kiro-validate-impl {feature}`（単独で再検証する場合）
+- 進捗確認: `/kiro-spec-status {feature}`（いつでも使ってよい）
 
-## Skills Structure
-Skills are located in `.claude/skills/kiro-*/SKILL.md`
-- Each skill is a directory with a `SKILL.md` file
-- Skills run inline with access to conversation context
-- Skills may delegate parallel research to subagents for efficiency
-- Additional files (templates, examples) can be added to skill directories
-- `kiro-review` — task-local adversarial review protocol used by reviewer subagents
-- `kiro-debug` — root-cause-first debug protocol used by debugger subagents
-- `kiro-verify-completion` — fresh-evidence gate before success or completion claims
-- **If there is even a 1% chance a skill applies to the current task, invoke it.** Do not skip skills because the task seems simple.
+## スキル構成
+スキルは `.claude/skills/kiro-*/SKILL.md` に置かれている。
+- 各スキルは `SKILL.md` を持つディレクトリ
+- スキルは会話のコンテキストを参照しながらインラインで動く
+- 効率のため、並列調査を subagent へ委譲することがある
+- テンプレートや例などのファイルをスキルのディレクトリに追加してよい
+- `kiro-review` — レビュアの subagent が使う、タスク単位の敵対的レビュー手順
+- `kiro-debug` — デバッガの subagent が使う、根本原因を先に取る debug 手順
+- `kiro-verify-completion` — 成功・完了を主張する前に、新しい証拠を要求するゲート
+- **現在のタスクにスキルが該当する見込みが1%でもあるなら、呼び出すこと。**
+  簡単そうに見えるという理由でスキルを飛ばさない。
 
-## Development Rules
-- 3-phase approval workflow: Requirements → Design → Tasks → Implementation
-- Human review required each phase; use `-y` only for intentional fast-track
-- Keep steering current and verify alignment with `/kiro-spec-status`
-- Follow the user's instructions precisely, and within that scope act autonomously: gather the necessary context and complete the requested work end-to-end in this run, asking questions only when essential information is missing or the instructions are critically ambiguous.
+## 開発規則
+- 3段階の承認ワークフロー: 要件 → 設計 → タスク → 実装
+- 各フェーズで人間のレビューが必要。`-y` は意図的に早送りする場合のみ使う
+- ステアリングを最新に保ち、`/kiro-spec-status` で整合を確認する
+- ユーザーの指示に正確に従い、その範囲内では自律的に動くこと。必要な背景を自分で集め、
+  依頼された作業をこの実行の中で最後までやり切る。質問するのは、不可欠な情報が
+  欠けているか、指示が決定的に曖昧なときに限る。
 
-## Steering Configuration
-- Load entire `.kiro/steering/` as project memory
-- Default files: `product.md`, `tech.md`, `structure.md`
-- Custom files are supported (managed via `/kiro-steering-custom`)
+## ステアリングの設定
+- `.kiro/steering/` 全体をプロジェクトメモリとして読み込む
+- 既定のファイル: `product.md`、`tech.md`、`structure.md`
+- カスタムファイルにも対応（`/kiro-steering-custom` で管理する）


### PR DESCRIPTION
## 問題

グローバルの言語ポリシーが 2026-08-01 に「指示文書の散文は日本語」へ変更されたが、
このリポジトリの `CLAUDE.md` は `cc-sdd v3` テンプレート（`67ef2777`）から
引き継いだ英語のままになっている。

新しく書き足す節だけ日本語にすると混在するため、先に全体を揃える。

## 解決

散文を日本語化する。**英語のまま残したもの**:

- スラッシュコマンド（`/kiro-spec-init` など）
- パスとファイル名（`.kiro/steering/`、`requirements.md` など）
- スキル識別子（`kiro-review`、`kiro-debug`、`kiro-verify-completion`）
- フラグ（`-y`、`--auto`）

## 確認

- 見出し数 10 → 10 で対応
- 原文に含まれる識別子（バッククォート囲みとスラッシュコマンド）の欠落なし。
  差分は追加側のみで、これは平文だったファイル名にバッククォートを付けたため
  （`requirements.md`、`design.md`、`tasks.md`、`research.md`、`brief.md`、
  `roadmap.md`、`spec.json`）
- 英語の散文の残存なし

## 副作用

`cc-sdd` テンプレートから乖離するため、次に cc-sdd を更新するときは
`CLAUDE.md` が衝突する。これは承知のうえ。上流の変更を黙って上書きするより、
衝突して気づけるほうがよいと判断した。

## 関連

この後、以前 #251 で出した「headless と neowright の使い分け」を、
更新済みの `master` から出し直す。