### PR TITLE
feat: add mfussenegger/nvim-lint

### DIFF
--- a/lua/plugins/nvim-lint/cmds.lua
+++ b/lua/plugins/nvim-lint/cmds.lua
@@ -1,0 +1,10 @@
+---@type table
+local cmds = {
+  "Lint",
+  "LintDisable",
+  "LintEnable",
+  "LintToggle",
+  "LintInfo",
+}
+
+return cmds

--- a/lua/plugins/nvim-lint/events.lua
+++ b/lua/plugins/nvim-lint/events.lua
@@ -1,0 +1,9 @@
+---@type table
+local events = {
+  --"VeryLazy",
+  -- conform formats on BufWritePre, so linting on BufWritePost always sees the formatted buffer
+  "BufReadPost",
+  "BufWritePost",
+}
+
+return events

--- a/lua/plugins/nvim-lint/init.lua
+++ b/lua/plugins/nvim-lint/init.lua
@@ -1,0 +1,158 @@
+---@type LazySpec
+local spec = {
+  "mfussenegger/nvim-lint",
+  --lazy = false,
+  cmd = require("plugins.nvim-lint.cmds"),
+  keys = require("plugins.nvim-lint.keys"),
+  event = require("plugins.nvim-lint.events"),
+  --opts = require("plugins.nvim-lint.opts"),
+  config = function()
+    local opts = require("plugins.nvim-lint.opts")
+    local lint = require("lint")
+
+    lint.linters_by_ft = opts.linters_by_ft
+
+    -- nvim-lint has no setup().
+    -- Built-in linter definitions are plain modules cached by `require`, so extending them in place is what actually sticks.
+    for name, override in pairs(opts.linters) do
+      local linter = lint.linters[name]
+
+      if linter and override.append_args then
+        linter.args = vim.list_extend(vim.deepcopy(linter.args or {}), override.append_args)
+      end
+    end
+
+    -- Resolve a linter's command the same way nvim-lint does:
+    -- it may be a function so the linter can prefer a project-local binary.
+    ---@param linter table
+    ---@return boolean
+    local function available(linter)
+      local cmd = linter.cmd
+
+      if type(cmd) == "function" then
+        local ok, resolved = pcall(cmd)
+
+        if not ok then
+          return false
+        end
+
+        cmd = resolved
+      end
+
+      return type(cmd) == "string" and vim.fn.executable(cmd) == 1
+    end
+
+    -- `linters_by_ft` names every linter worth running, not just the ones that happen to be installed on this host.
+    -- Without this filter try_lint emits a WARN per missing executable on every save.
+    -- `:LintInfo` reports what got skipped, since skipping is otherwise silent.
+    local function lint_buf()
+      local bufnr = vim.api.nvim_get_current_buf()
+
+      if vim.g.disable_lint or vim.b[bufnr].disable_lint then
+        return
+      end
+
+      lint.try_lint(nil, {
+        filter = available,
+      })
+      lint.try_lint(opts.extra_linters(bufnr), {
+        filter = available,
+      })
+    end
+
+    vim.api.nvim_create_autocmd(require("plugins.nvim-lint.events"), {
+      desc = "Run nvim-lint on the current buffer",
+      callback = lint_buf,
+    })
+
+    -- Define some user_commands
+    -- Lint on demand
+    vim.api.nvim_create_user_command("Lint", lint_buf, {
+      desc = "Lint the current buffer",
+    })
+
+    -- Run Enable/Disable
+    vim.api.nvim_create_user_command("LintDisable", function(args)
+      if args.bang then
+        -- LintDisable! will disable linting just for this buffer
+        vim.b.disable_lint = true
+      else
+        vim.g.disable_lint = true
+      end
+    end, {
+      desc = "Disable lint-on-save",
+      bang = true,
+    })
+
+    vim.api.nvim_create_user_command("LintEnable", function()
+      vim.b.disable_lint = false
+      vim.g.disable_lint = false
+    end, {
+      desc = "Re-enable lint-on-save",
+    })
+
+    -- Toggle lint-on-save (mirrors the bang semantics of LintDisable)
+    vim.api.nvim_create_user_command("LintToggle", function(args)
+      if args.bang then
+        -- LintToggle! flips linting just for this buffer
+        vim.b.disable_lint = not vim.b.disable_lint
+      else
+        vim.g.disable_lint = not vim.g.disable_lint
+      end
+    end, {
+      desc = "Toggle lint-on-save",
+      bang = true,
+    })
+
+    -- Report which linters apply to this buffer and which of them are missing.
+    -- This is the counterpart to the `available` filter above.
+    vim.api.nvim_create_user_command("LintInfo", function()
+      local bufnr = vim.api.nvim_get_current_buf()
+      local filetype = vim.bo[bufnr].filetype
+      local disabled = vim.g.disable_lint or vim.b[bufnr].disable_lint or false
+      local lines = {
+        "filetype: " .. (filetype == "" and "(none)" or filetype),
+        "lint-on-save: " .. (disabled and "disabled" or "enabled"),
+        "legend: + installed / - not on PATH",
+      }
+
+      local function report(names)
+        if vim.tbl_isempty(names) then
+          table.insert(lines, "  (none)")
+
+          return
+        end
+
+        for _, name in ipairs(names) do
+          local linter = lint.linters[name]
+
+          if type(linter) == "function" then
+            linter = linter()
+          end
+
+          if linter then
+            table.insert(lines, (available(linter) and "  + " or "  - ") .. name)
+          else
+            table.insert(lines, "  ? " .. name .. " (no definition)")
+          end
+        end
+      end
+
+      table.insert(lines, "")
+      table.insert(lines, "by filetype:")
+      report(lint.linters_by_ft[filetype] or {})
+
+      table.insert(lines, "")
+      table.insert(lines, "always:")
+      report(opts.extra_linters(bufnr))
+
+      vim.notify(table.concat(lines, "\n"), vim.log.levels.INFO)
+    end, {
+      desc = "Show the linters configured for the current buffer",
+    })
+  end,
+  --cond = false,
+  --enabled = false,
+}
+
+return spec

--- a/lua/plugins/nvim-lint/keys.lua
+++ b/lua/plugins/nvim-lint/keys.lua
@@ -1,0 +1,17 @@
+---@type LazyKeysSpec[]
+local keys = {
+  {
+    -- <leader>l is quicker.nvim's loclist toggle
+    "<leader>L",
+    function()
+      vim.cmd("Lint")
+    end,
+    mode = {
+      "n",
+    },
+    desc = "Lint buffer",
+    silent = true,
+  },
+}
+
+return keys

--- a/lua/plugins/nvim-lint/opts.lua
+++ b/lua/plugins/nvim-lint/opts.lua
@@ -1,0 +1,106 @@
+---@type table
+local opts = {
+  -- Map of filetype to linters.
+
+  -- nvim-lint has no `["*"]` filetype:
+  -- `_resolve_linter_by_ft` only looks up the buffer's own filetype (splitting compound ones like `yaml.ghaction` on dots).
+  -- Linters that have to run everywhere live in `extra_linters` below.
+
+  -- The toolchain mirrors `plugins.conform-nvim.opts` wherever both sides ship a tool for the same filetype, so formatting and linting never disagree about style.
+  -- Filetypes conform formats but nvim-lint has no linter for (xml, cs, scala, dart, cabal, ocaml, elm, gleam, hcl, nginx, kdl, just, templ) are omitted rather than filled with an unrelated tool.
+  linters_by_ft = {
+    -- Config / shell
+    -- selene is also this repo's own linter, configured by ./selene.toml
+    lua = { "selene" },
+    fish = { "fish" },
+    sh = { "shellcheck" },
+    bash = { "shellcheck" },
+    zsh = { "zsh" },
+    -- Data / markup
+    toml = { "tombi" },
+    yaml = { "yamllint" },
+    json = { "jsonlint" },
+    markdown = { "rumdl" },
+    -- Systems / compiled
+    rust = { "clippy" },
+    go = { "golangcilint" },
+    zig = { "zlint" },
+    c = { "cppcheck" },
+    cpp = { "cppcheck" },
+    kotlin = { "ktlint" },
+    java = { "checkstyle" },
+    swift = { "swiftlint" },
+    -- Scripting / dynamic
+    python = { "ruff" },
+    ruby = { "rubocop" },
+    -- The Neovim filetype for ERB is `eruby`
+    eruby = { "erb_lint" },
+    perl = { "perlcritic" },
+    php = { "phpcs" },
+    -- Web front-end
+    javascript = { "biomejs" },
+    typescript = { "biomejs" },
+    css = { "biomejs" },
+    -- biome has no SCSS support, so this is the one spot where linting and formatting use different tools
+    scss = { "stylelint" },
+    html = { "htmlhint" },
+    vue = { "eslint" },
+    svelte = { "eslint" },
+    astro = { "eslint" },
+    -- Functional / ML-family
+    haskell = { "hlint" },
+    elixir = { "credo" },
+    fennel = { "fennel" },
+    -- Infra / config-as-code
+    nix = { "statix", "deadnix" },
+    sql = { "sqlfluff" },
+    terraform = { "tflint" },
+    cmake = { "cmakelint" },
+    -- Typesetting
+    -- The Neovim filetype for LaTeX/.tex is `tex`
+    tex = { "chktex" },
+    -- Lint-only: nothing in conform covers these
+    dockerfile = { "hadolint" },
+    make = { "checkmake" },
+    vim = { "vint" },
+    gitcommit = { "gitlint" },
+  },
+
+  -- Linters that run regardless of `linters_by_ft`, decided per buffer.
+  ---@param bufnr integer
+  ---@return string[]
+  extra_linters = function(bufnr)
+    -- typos is the reason this plugin exists: it used to run as a conform formatter over `["*"]` with `--write-changes` and corrupted files on save.
+    -- As a linter it only reports.
+    local names = {
+      "typos",
+    }
+
+    -- actionlint and zizmor only make sense on GitHub Actions workflows.
+    -- Upstream suggests a `yaml.ghaction` filetype pattern, but a compound filetype changes which language servers attach to the buffer;
+    -- matching the path keeps the effect contained to linting.
+    if vim.api.nvim_buf_get_name(bufnr):match("/%.github/workflows/") then
+      vim.list_extend(names, {
+        "actionlint",
+        "zizmor",
+      })
+    end
+
+    return names
+  end,
+
+  -- Overrides for built-in linter definitions.
+  -- `append_args` mirrors the key of the same name in `plugins.conform-nvim.opts`.
+  linters = {
+    typos = {
+      -- The default dictionary rewrites `edn` -> `end`, which is wrong for Clojure EDN.
+      -- `--config` merges with a project-local `_typos.toml` rather than replacing it, so per-project settings still apply.
+      append_args = {
+        "--config",
+        require("config.host").paths.config .. "/typos.toml",
+      },
+    },
+  },
+}
+
+return opts

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,9 @@
+# typos configuration for the nvim-lint `typos` linter.
+#
+# Passed with `--config` from lua/plugins/nvim-lint/opts.lua, which merges with a
+# project-local `_typos.toml` instead of replacing it.
+
+[default.extend-words]
+# Clojure EDN. The default dictionary rewrites `edn` -> `end`, which corrupted
+# .edn files back when typos ran as a conform formatter with --write-changes.
+edn = "edn"


### PR DESCRIPTION
## 問題

typos を conform の formatter として `["*"]` + `--write-changes` で全ファイルに
掛けていたため、標準辞書の `edn` -> `end` 補正が発火し、Clojure の EDN が
**保存するたびに壊れていた**。

暫定対処として `conform-nvim/opts.lua` から `["*"] = { "typos" }` を外したので
破壊は止まっているが、代わりに typo 検知そのものが無くなっている。

責務の切り分けは当時のコメント（`conform-nvim/opts.lua`）に書いたとおり:

- conform = フォーマッタ。構造上バッファを書き換える＝修正専用
- 「検知のみ・修正しない」はリンタの仕事

つまり nvim-lint が要る。

## 解決

`mfussenegger/nvim-lint` を入れ、typos を**検知のみ**で復活させる。

### 誤検知そのものを止める

リポジトリ直下に `typos.toml` を置き、`--config` で渡す。

```toml
[default.extend-words]
edn = "edn"
```

`--config` はプロジェクトローカルの `_typos.toml` を上書きせず**マージ**するので、
各プロジェクト固有の設定は生きたまま。

### リンタ構成

`linters_by_ft` は `conform-nvim/opts.lua` の `formatters_by_ft` と同じ見出し区分で
書き、**両方にツールがある filetype はツールチェーンを揃えた**（biome / ruff /
rumdl / tombi / rubocop / ktlint / sqlfluff / tflint など）。整形と lint が
スタイルの解釈で食い違わないようにするため。

- conform 側にしか無いもの（xml, cs, scala, dart, cabal, ocaml, elm, gleam, hcl,
  nginx, kdl, just, templ）は、無関係なツールで埋めずに省いた
- lint 側にしか無いものを4つ追加: dockerfile / make / vim / gitcommit
- `scss` だけは整形が biome、lint が stylelint に分かれる（biome が SCSS 非対応）

### 未インストールのリンタで通知が鳴らないようにする

`linters_by_ft` は「このホストに入っているもの」ではなく「回す価値があるもの」を
全部書いている。nvim-lint は実行ファイルが無いと保存のたびに WARN を出すので、
`try_lint` の `filter` で `vim.fn.executable()` を見て落とす。

`cmd` は文字列とは限らない（biomejs / eslint / stylelint / phpcs は
`./node_modules/.bin/` を優先するため関数）。本体が `eval(linter.cmd)` して
いるので、こちらも同じ解決をしてから判定する。

黙って飛ばすと「なぜ lint されないのか」が分からなくなるため、対になる
`:LintInfo` を用意した。現在のバッファの filetype・対象リンタ・各々が PATH に
あるか（`+` / `-`）を出す。

### 全ファイル対象のリンタ

nvim-lint に `["*"]` は無い（`_resolve_linter_by_ft` は filetype しか引かない）
ので、`opts.extra_linters(bufnr)` を用意して `try_lint` を別途呼ぶ。

- typos は常時
- actionlint / zizmor は `/.github/workflows/` 配下のときだけ

upstream は `yaml.ghaction` という複合 filetype を勧めているが、複合 filetype は
どの LSP がアタッチするかに影響するので、パス一致にして影響を lint 内に閉じた。

### 操作

conform に揃えた。`ConformDisable!` と同じ bang セマンティクス
（bang ありはバッファ単位 = `vim.b`、無しはグローバル = `vim.g`）。

| | conform | nvim-lint |
|---|---|---|
| 実行 | `<leader>f` / `:Conform` | `<leader>L` / `:Lint` |
| 切り替え | `:ConformDisable` / `Enable` / `Toggle` | `:LintDisable` / `Enable` / `Toggle` |
| 情報 | `:ConformInfo` | `:LintInfo` |

`<leader>l` は quicker.nvim の loclist toggle が使用中なので大文字。

イベントは `BufReadPost` + `BufWritePost`。conform が `BufWritePre` で整形するので、
lint は必ず整形後の内容を見る。

## 動作確認

`stylua --check` / `selene`（0 error 0 warning）/ `task check-keys` に加えて、
neowright で実 TUI を確認した。

- `.edn` に `{:foo "bar" :edn true :recieve 1}` → `recieve` だけ出て **`edn` は出ない**
- ファイルを開くと selene と `[typos] typo` の diagnostics が自動で出る
- `:LintToggle` 後は保存しても nvim-lint の diagnostics が更新されない。もう一度で追従
- `.hs`（hlint 未導入）を開いて `:messages` が空 — フィルタが効いている
- `:LintInfo` が `filetype: haskell` / `- hlint` / `+ typos` を表示
- `extra_linters`: workflow パス → `{typos, actionlint, zizmor}`、他 → `{typos}`
