### PR TITLE
feat: add mason-conform.nvim and mason-nvim-lint specs

### DIFF
--- a/lua/plugins/mason-conform-nvim/cmds.lua
+++ b/lua/plugins/mason-conform-nvim/cmds.lua
@@ -1,0 +1,7 @@
+---@type string[]
+local cmds = {
+  "ConformInstall",
+  "ConformUninstall",
+}
+
+return cmds

--- a/lua/plugins/mason-conform-nvim/dependencies.lua
+++ b/lua/plugins/mason-conform-nvim/dependencies.lua
@@ -1,0 +1,11 @@
+-- NOTE: listing conform.nvim here makes it load when this plugin loads, which
+-- is earlier than its own BufWritePre/cmd/keys triggers. That is required:
+-- mason-conform reads `formatters_by_ft` out of a configured conform, and an
+-- unloaded conform has an empty one.
+---@type LazySpec[]
+local dependencies = {
+  "mason-org/mason.nvim",
+  "stevearc/conform.nvim",
+}
+
+return dependencies

--- a/lua/plugins/mason-conform-nvim/events.lua
+++ b/lua/plugins/mason-conform-nvim/events.lua
@@ -1,0 +1,8 @@
+-- VeryLazy, matching mason-nvim and mason-lspconfig-nvim: package installation
+-- has no reason to happen before the UI is up.
+---@type string[]
+local events = {
+  "VeryLazy",
+}
+
+return events

--- a/lua/plugins/mason-conform-nvim/init.lua
+++ b/lua/plugins/mason-conform-nvim/init.lua
@@ -1,0 +1,20 @@
+---@type LazySpec
+local spec = {
+  -- Local checkout while this is being developed. Swap for "mimikun/mason-conform.nvim"
+  -- once it is pushed.
+  dir = vim.fn.expand("~/ghq/github.com/mimikun/mason-conform.nvim"),
+  name = "mason-conform.nvim",
+  --lazy = false,
+  dependencies = require("plugins.mason-conform-nvim.dependencies"),
+  cmd = require("plugins.mason-conform-nvim.cmds"),
+  event = require("plugins.mason-conform-nvim.events"),
+  --opts = require("plugins.mason-conform-nvim.opts"),
+  config = function()
+    local opts = require("plugins.mason-conform-nvim.opts")
+    require("mason-conform").setup(opts)
+  end,
+  --cond = false,
+  --enabled = false,
+}
+
+return spec

--- a/lua/plugins/mason-conform-nvim/opts.lua
+++ b/lua/plugins/mason-conform-nvim/opts.lua
@@ -1,0 +1,22 @@
+---@type table
+local opts = {
+  -- Formatters conform points at that mason has no package for are skipped
+  -- silently, so nothing needs listing here yet. Anything conform cannot
+  -- express goes here, using mason package names.
+  ---@type string[]
+  ensure_installed = {},
+
+  -- Install every formatter in conform's formatters_by_ft that mason carries.
+  -- 31 of the 51 configured formatters resolve; the rest ship with their own
+  -- toolchain (rustfmt, gofmt, zigfmt, mix, fish_indent, ...) or are absent
+  -- from the registry. Run :checkhealth mason-conform to see the split.
+  ---@type boolean | string[] | { exclude: string[] }
+  automatic_installation = true,
+
+  -- Resolution is derived from the mason registry, not a table in the plugin.
+  -- This is the escape hatch for a bad derivation.
+  ---@type table<string, string|false>
+  overrides = {},
+}
+
+return opts

--- a/lua/plugins/mason-nvim-lint/cmds.lua
+++ b/lua/plugins/mason-nvim-lint/cmds.lua
@@ -1,0 +1,7 @@
+---@type string[]
+local cmds = {
+  "LintInstall",
+  "LintUninstall",
+}
+
+return cmds

--- a/lua/plugins/mason-nvim-lint/dependencies.lua
+++ b/lua/plugins/mason-nvim-lint/dependencies.lua
@@ -1,0 +1,11 @@
+-- NOTE: listing nvim-lint here makes it load when this plugin loads, which is
+-- earlier than its own BufReadPost/BufWritePost triggers. That is required:
+-- mason-nvim-lint reads `linters_by_ft` out of a configured nvim-lint, and an
+-- unloaded nvim-lint has an empty one.
+---@type LazySpec[]
+local dependencies = {
+  "mason-org/mason.nvim",
+  "mfussenegger/nvim-lint",
+}
+
+return dependencies

--- a/lua/plugins/mason-nvim-lint/events.lua
+++ b/lua/plugins/mason-nvim-lint/events.lua
@@ -1,0 +1,8 @@
+-- VeryLazy, matching mason-nvim and mason-lspconfig-nvim: package installation
+-- has no reason to happen before the UI is up.
+---@type string[]
+local events = {
+  "VeryLazy",
+}
+
+return events

--- a/lua/plugins/mason-nvim-lint/init.lua
+++ b/lua/plugins/mason-nvim-lint/init.lua
@@ -1,0 +1,20 @@
+---@type LazySpec
+local spec = {
+  -- Local checkout while this is being developed. Swap for "mimikun/mason-nvim-lint"
+  -- once it is pushed.
+  dir = vim.fn.expand("~/ghq/github.com/mimikun/mason-nvim-lint"),
+  name = "mason-nvim-lint",
+  --lazy = false,
+  dependencies = require("plugins.mason-nvim-lint.dependencies"),
+  cmd = require("plugins.mason-nvim-lint.cmds"),
+  event = require("plugins.mason-nvim-lint.events"),
+  --opts = require("plugins.mason-nvim-lint.opts"),
+  config = function()
+    local opts = require("plugins.mason-nvim-lint.opts")
+    require("mason-nvim-lint").setup(opts)
+  end,
+  --cond = false,
+  --enabled = false,
+}
+
+return spec

--- a/lua/plugins/mason-nvim-lint/opts.lua
+++ b/lua/plugins/mason-nvim-lint/opts.lua
@@ -1,0 +1,27 @@
+---@type table
+local opts = {
+  -- automatic_installation only sees linters_by_ft. The ones nvim-lint's
+  -- `extra_linters` passes straight to try_lint() are invisible to it, so they
+  -- are named here with their mason package names.
+  -- See lua/plugins/nvim-lint/opts.lua.
+  ---@type string[]
+  ensure_installed = {
+    "typos",
+    "actionlint",
+    "zizmor",
+  },
+
+  -- Install every linter in nvim-lint's linters_by_ft that mason carries.
+  -- 26 of the 37 configured linters resolve; the rest run through their own
+  -- toolchain (clippy via cargo, credo via mix, fish and zsh are the shells)
+  -- or are absent from the registry. Run :checkhealth mason-nvim-lint.
+  ---@type boolean | string[] | { exclude: string[] }
+  automatic_installation = true,
+
+  -- Resolution is derived from the mason registry, not a table in the plugin.
+  -- This is the escape hatch for a bad derivation.
+  ---@type table<string, string|false>
+  overrides = {},
+}
+
+return opts


### PR DESCRIPTION
## Problem

None of the ~50 formatters configured in conform.nvim nor the ~45 linters in
nvim-lint were being installed by anything. The breakage was invisible:
nvim-lint silently skips linters missing from `PATH` via its `available()`
filter, and conform falls back to `lsp_format = "fallback"`. So both looked
configured while doing nothing.

`mason-lspconfig-nvim/opts/ensure_installed.lua` cannot cover them — it only
accepts lspconfig server names, so `shfmt` and `shellcheck` have no home there.

Every existing bridge plugin is either archived, abandoned, points the wrong
direction, or carries a hand-written mapping table that goes stale silently.

## Solution

Two plugins written for this, referenced locally via `dir=` for now:

- `mimikun/mason-conform.nvim`
- `mimikun/mason-nvim-lint`

Both derive the tool-to-package mapping from the mason registry's `bin` and
`categories` fields instead of pinning a table, so registry renames and
additions are picked up without edits here. 152 of 263 formatters and 109 of
186 linters resolve. Tools shipped by their own toolchain (`rustfmt`, `gofmt`,
`clippy`) resolve to nothing and are skipped without a warning.

`nvim-lint`'s `opts.lua` sets `ensure_installed` explicitly for `typos`,
`actionlint` and `zizmor`: `automatic_installation` only sees `linters_by_ft`,
and those three reach `try_lint()` directly, where nvim-lint keeps no record of
them.

Listing conform.nvim and nvim-lint under `dependencies` moves their load from
`BufWritePre`/`BufReadPost` up to `VeryLazy`. That is required — the filetype
tables are read at setup time, and an unloaded plugin has empty ones. Both
`dependencies.lua` files note this.

## Verification

- Real session: 31 of 45 configured formatters and 26 of 37 configured linters
  resolve; `:checkhealth` clean for both
- Installation confirmed end-to-end (mason store 172 -> 211 packages)
- `stylua --check`, `selene` (0/0 on the new files), `task check-keys` (51 files)

Swap `dir=` for the GitHub shorthand once the two repositories are pushed.