### PR TITLE
refactor: resolve mason tool plugins through lazy dev

### DIFF
--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -54,7 +54,10 @@ require("lazy").setup({
     root = vim.fn.stdpath("data") .. "/lazy-rocks",
   },
   dev = {
-    path = "~/projects",
+    -- ghq layout, so a spec's name matches its directory here.
+    path = "~/ghq/github.com/mimikun",
+    -- `patterns` is left empty on purpose: only specs that opt in with
+    -- `dev = true` resolve locally.
     fallback = false,
   },
   install = {

--- a/lua/plugins/mason-conform-nvim/init.lua
+++ b/lua/plugins/mason-conform-nvim/init.lua
@@ -1,9 +1,10 @@
 ---@type LazySpec
 local spec = {
-  -- Local checkout while this is being developed. Swap for "mimikun/mason-conform.nvim"
-  -- once it is pushed.
-  dir = vim.fn.expand("~/ghq/github.com/mimikun/mason-conform.nvim"),
-  name = "mason-conform.nvim",
+  -- Private repository, so lazy.nvim cannot clone it over the default HTTPS
+  -- url_format. `dev = true` resolves it under `dev.path` in lua/config/lazy.lua
+  -- instead, which is where ghq already put it.
+  "mimikun/mason-conform.nvim",
+  dev = true,
   --lazy = false,
   dependencies = require("plugins.mason-conform-nvim.dependencies"),
   cmd = require("plugins.mason-conform-nvim.cmds"),

--- a/lua/plugins/mason-nvim-lint/init.lua
+++ b/lua/plugins/mason-nvim-lint/init.lua
@@ -1,9 +1,11 @@
 ---@type LazySpec
 local spec = {
-  -- Local checkout while this is being developed. Swap for "mimikun/mason-nvim-lint"
-  -- once it is pushed.
-  dir = vim.fn.expand("~/ghq/github.com/mimikun/mason-nvim-lint"),
-  name = "mason-nvim-lint",
+  -- Private repository, so lazy.nvim cannot clone it over the default HTTPS
+  -- url_format. `dev = true` resolves it under `dev.path` in lua/config/lazy.lua
+  -- instead, which is where ghq already put it. The directory is named after the
+  -- repository, not after the Lua module.
+  "mimikun/mason-nvim-lint.nvim",
+  dev = true,
   --lazy = false,
   dependencies = require("plugins.mason-nvim-lint.dependencies"),
   cmd = require("plugins.mason-nvim-lint.cmds"),


### PR DESCRIPTION
## Problem

`mason-conform.nvim` and `mason-nvim-lint.nvim` are now pushed, but both
repositories are **private**. lazy.nvim's default `url_format` is
`https://github.com/%s.git`, which cannot clone a private repository without
interactive HTTPS credentials, so the plain `"mimikun/..."` shorthand does not
work here.

The specs were therefore still carrying an absolute `dir =` path left over from
local development.

## Solution

Use lazy's `dev` mechanism instead. It resolves a plugin to
`dev.path/<spec name>`, and ghq already lays checkouts out in exactly that
shape, so no path duplication is needed in the specs.

- `dev.path` moves from `~/projects` — which does not exist on this machine, so
  `dev` was unusable — to `~/ghq/github.com/mimikun`
- `dev.patterns` stays empty on purpose. Filling it in would make all 34
  repositories under that path resolve locally; empty means only specs that opt
  in with `dev = true` do
- `dev.fallback` stays `false`. Without the local checkout the plugin fails
  loudly rather than falling back to a clone that would fail anyway

The nvim-lint spec is `mimikun/mason-nvim-lint.nvim`: the repository carries the
`.nvim` suffix even though the Lua module does not, and dev resolution keys off
the repository name. The local checkout was renamed to match.

## Verification

Resolution, in a real config load:

```
conform dir = ~/ghq/github.com/mimikun/mason-conform.nvim    dev = true
lint    dir = ~/ghq/github.com/mimikun/mason-nvim-lint.nvim  dev = true
```

Both `Lazy! load` cleanly and register all four commands (`ConformInstall`,
`ConformUninstall`, `LintInstall`, `LintUninstall`).

`stylua --check` passes, `task check-keys` OK across 51 files, and selene is
unchanged from master at 2 errors / 23 warnings — all pre-existing, all under
`lua/plugins/conform-nvim/formatters/`.