### PR TITLE
fix: stop rumdl from littering the cwd, and find the next tool that does

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -121,3 +121,11 @@ tasks:
     cmds:
       - "{{.TASKFILE_DIR}}/scripts/check-options-sync.sh"
     silent: true
+
+  check-tool-litter:
+    desc: "Find formatters/linters that write into the working directory (e.g. ./.rumdl_cache)"
+    aliases:
+      - ctl
+    cmds:
+      - "{{.TASKFILE_DIR}}/scripts/check-tool-litter.sh {{.CLI_ARGS}}"
+    silent: true

--- a/init.lua
+++ b/init.lua
@@ -3,6 +3,7 @@ if vim.loader then
 end
 
 require("config.variables")
+require("config.tool_cache")
 require("config.options")
 require("config.lazy")
 require("config.autocmds")

--- a/lua/config/tool_cache.lua
+++ b/lua/config/tool_cache.lua
@@ -1,0 +1,35 @@
+-- Point tools that default their cache at the current directory somewhere else.
+--
+-- Why
+--   Neovim runs formatters, linters and language servers with the cwd set to
+--   whatever the user happens to be editing in, so a tool that caches into `.`
+--   scatters directories through every project it touches. rumdl defaults to
+--   ./.rumdl_cache and needed two separate fixes before it was noticed, one per
+--   call path (conform, then nvim-lint), with a third path (its language server)
+--   still uncovered.
+--
+--   Per-call-path CLI flags cannot close that off: the number of places to
+--   remember is tools x call paths, and a new call path silently reopens the
+--   hole. The process environment is one place that covers every path at once,
+--   including servers this config does not pass arguments to.
+--
+--   The trade-off is that a `rumdl` typed into a :terminal inherits this too. It
+--   caches under stdpath("cache") instead of the cwd, which is the behaviour
+--   wanted there as well.
+--
+-- Adding a tool
+--   Add its cache environment variable below. Run `task check-tool-litter` to
+--   find out which tools need it: it runs every configured formatter and linter
+--   in an empty directory and reports what each leaves behind.
+
+local host = require("config.host")
+
+-- Tool cache environment variable -> directory under stdpath("cache").
+local dirs = {
+  -- rumdl: markdown formatter (conform), linter (nvim-lint) and language server.
+  RUMDL_CACHE_DIR = "rumdl",
+}
+
+for name, dir in pairs(dirs) do
+  vim.env[name] = host.paths.cache .. "/" .. dir
+end

--- a/lua/plugins/nvim-lint/apply_overrides.lua
+++ b/lua/plugins/nvim-lint/apply_overrides.lua
@@ -1,0 +1,32 @@
+-- Apply `plugins.nvim-lint.opts.linters` on top of nvim-lint's built-in linter
+-- definitions.
+--
+-- nvim-lint has no setup(). Built-in linter definitions are plain modules cached
+-- by `require`, so extending them in place is what actually sticks.
+--
+-- Lives in its own module because two callers need the exact same resolved
+-- argv: the plugin's own `config` function, and scripts/check-tool-litter.lua,
+-- which audits what each tool writes into the working directory. A copy of this
+-- loop in the checker would silently drift from what actually runs.
+--
+-- `append_args` extends the built-in argument list; every other key replaces the
+-- field outright.
+
+---@param lint table The `lint` module.
+---@param overrides table<string, table> Keyed by linter name.
+---@return nil
+return function(lint, overrides)
+  for name, override in pairs(overrides) do
+    local linter = lint.linters[name]
+
+    if linter then
+      for key, value in pairs(override) do
+        if key == "append_args" then
+          linter.args = vim.list_extend(vim.deepcopy(linter.args or {}), value)
+        else
+          linter[key] = value
+        end
+      end
+    end
+  end
+end

--- a/lua/plugins/nvim-lint/init.lua
+++ b/lua/plugins/nvim-lint/init.lua
@@ -12,22 +12,7 @@ local spec = {
 
     lint.linters_by_ft = opts.linters_by_ft
 
-    -- nvim-lint has no setup().
-    -- Built-in linter definitions are plain modules cached by `require`, so extending them in place is what actually sticks.
-    -- `append_args` extends the built-in argument list; every other key replaces the field outright.
-    for name, override in pairs(opts.linters) do
-      local linter = lint.linters[name]
-
-      if linter then
-        for key, value in pairs(override) do
-          if key == "append_args" then
-            linter.args = vim.list_extend(vim.deepcopy(linter.args or {}), value)
-          else
-            linter[key] = value
-          end
-        end
-      end
-    end
+    require("plugins.nvim-lint.apply_overrides")(lint, opts.linters)
 
     -- Resolve a linter's command the same way nvim-lint does:
     -- it may be a function so the linter can prefer a project-local binary.

--- a/lua/plugins/nvim-lint/init.lua
+++ b/lua/plugins/nvim-lint/init.lua
@@ -14,11 +14,18 @@ local spec = {
 
     -- nvim-lint has no setup().
     -- Built-in linter definitions are plain modules cached by `require`, so extending them in place is what actually sticks.
+    -- `append_args` extends the built-in argument list; every other key replaces the field outright.
     for name, override in pairs(opts.linters) do
       local linter = lint.linters[name]
 
-      if linter and override.append_args then
-        linter.args = vim.list_extend(vim.deepcopy(linter.args or {}), override.append_args)
+      if linter then
+        for key, value in pairs(override) do
+          if key == "append_args" then
+            linter.args = vim.list_extend(vim.deepcopy(linter.args or {}), value)
+          else
+            linter[key] = value
+          end
+        end
       end
     end
 

--- a/lua/plugins/nvim-lint/opts.lua
+++ b/lua/plugins/nvim-lint/opts.lua
@@ -99,6 +99,9 @@ local opts = {
       append_args = {
         "--no-cache",
       },
+      -- The built-in definition reads diagnostics off stderr, but rumdl writes its JSON report to stdout.
+      -- Left alone, markdown linting silently produces zero diagnostics. Verified against rumdl 0.2.52.
+      stream = "stdout",
     },
     typos = {
       -- The default dictionary rewrites `edn` -> `end`, which is wrong for Clojure EDN.

--- a/lua/plugins/nvim-lint/opts.lua
+++ b/lua/plugins/nvim-lint/opts.lua
@@ -92,6 +92,14 @@ local opts = {
   -- Overrides for built-in linter definitions.
   -- `append_args` mirrors the key of the same name in `plugins.conform-nvim.opts`.
   linters = {
+    -- rumdl defaults its cache to ./.rumdl_cache, which litters every working directory when linting via stdin.
+    -- Caching brings no benefit here (stdin has no file identity to key on), so disable it.
+    -- Mirrors the identical override in `plugins.conform-nvim.opts`.
+    rumdl = {
+      append_args = {
+        "--no-cache",
+      },
+    },
     typos = {
       -- The default dictionary rewrites `edn` -> `end`, which is wrong for Clojure EDN.
       -- `--config` merges with a project-local `_typos.toml` rather than replacing it, so per-project settings still apply.

--- a/scripts/check-tool-litter.lua
+++ b/scripts/check-tool-litter.lua
@@ -1,0 +1,343 @@
+-- check-tool-litter.lua - Find formatters and linters that write into the
+-- working directory.
+--
+-- Run via the wrapper (recommended, cds to repo root first):
+--   scripts/check-tool-litter.sh
+-- or directly:
+--   nvim --headless -l scripts/check-tool-litter.lua [tool]...
+--
+-- Why
+--   Tools are supposed to put caches and scratch files under XDG_CACHE_HOME or
+--   a temp directory. Plenty of them default to the current directory instead:
+--   rumdl drops ./.rumdl_cache on every run, and it took two separate fixes to
+--   notice, because Neovim runs these tools with the cwd set to whatever the
+--   user happens to be editing in. The offenders are only discoverable by
+--   running each tool and looking, so this does exactly that.
+--
+-- How
+--   Every formatter in `plugins.conform-nvim.opts.formatters_by_ft` and every
+--   linter in `plugins.nvim-lint.opts` is resolved to the exact argv this
+--   config would run (overrides included, via conform's own `build_cmd` and
+--   `plugins.nvim-lint.apply_overrides`), then executed inside a fresh empty
+--   directory with a small sample file on stdin. Anything left behind in that
+--   directory afterwards is reported.
+--
+-- What it reports
+--   LITTER  - tool created the listed entries in the working directory.
+--   skipped - tool is not installed on this host, or its argv could not be
+--             resolved. Skips are not failures; the toolchain intentionally
+--             names more tools than any one machine installs.
+--
+--   A clean result is only evidence for the sample input used here. A tool that
+--   writes its cache only on a cache miss for a real project may still be
+--   quiet against a one-line sample.
+--
+-- Exit code: 0 when nothing littered, 1 when any tool did.
+
+local TIMEOUT_MS = 15000
+
+-- Extensions for filetypes whose name is not already the extension. Anything
+-- absent falls through to the filetype name, which is correct for lua, sh,
+-- json, toml, and most others.
+local EXTENSIONS = {
+  bash = "sh",
+  bib = "bib",
+  cmake = "cmake",
+  dockerfile = "Dockerfile",
+  eruby = "erb",
+  gitcommit = "COMMIT_EDITMSG",
+  javascript = "js",
+  javascriptreact = "jsx",
+  make = "Makefile",
+  markdown = "md",
+  python = "py",
+  ruby = "rb",
+  rust = "rs",
+  systemverilog = "sv",
+  typescript = "ts",
+  typescriptreact = "tsx",
+  verilog = "v",
+  vim = "vim",
+  yaml = "yaml",
+  zsh = "zsh",
+}
+
+-- Filetypes whose sample must parse for the tool to get far enough to write
+-- anything. A blank line is enough everywhere else.
+local SAMPLES = {
+  json = "{}\n",
+  lua = "local x = 1\n",
+  markdown = "# a\n\nfoo\n",
+  python = "x = 1\n",
+  sh = "x=1\n",
+  toml = "x = 1\n",
+  yaml = "x: 1\n",
+}
+
+local repo_root = vim.fn.getcwd()
+vim.opt.runtimepath:prepend(repo_root)
+
+local lazy_root = vim.fn.stdpath("data") .. "/lazy"
+vim.opt.runtimepath:append(lazy_root .. "/conform.nvim")
+vim.opt.runtimepath:append(lazy_root .. "/nvim-lint")
+
+local ok_conform, conform = pcall(require, "conform")
+local ok_runner, runner = pcall(require, "conform.runner")
+local ok_lint, lint = pcall(require, "lint")
+
+if not (ok_conform and ok_runner and ok_lint) then
+  io.stderr:write("conform.nvim and nvim-lint must be installed; run :Lazy install first\n")
+  os.exit(2)
+end
+
+local conform_opts = require("plugins.conform-nvim.opts")
+local lint_opts = require("plugins.nvim-lint.opts")
+
+conform.setup(conform_opts)
+lint.linters_by_ft = lint_opts.linters_by_ft
+require("plugins.nvim-lint.apply_overrides")(lint, lint_opts.linters)
+
+--- Every tool this config can run, each paired with one filetype it applies to.
+--- The filetype only decides the sample file's name and contents.
+---@return { name: string, kind: string, filetype: string }[]
+local function collect_tools()
+  local seen = {}
+  local tools = {}
+
+  local function add(name, kind, filetype)
+    if type(name) ~= "string" or seen[name] then
+      return
+    end
+
+    seen[name] = true
+    table.insert(tools, { name = name, kind = kind, filetype = filetype })
+  end
+
+  for filetype, names in pairs(conform_opts.formatters_by_ft or {}) do
+    -- Entries may be a plain list, or carry `stop_after_first` alongside it.
+    for _, name in ipairs(names) do
+      add(name, "formatter", filetype)
+    end
+  end
+
+  for filetype, names in pairs(lint_opts.linters_by_ft or {}) do
+    for _, name in ipairs(names) do
+      add(name, "linter", filetype)
+    end
+  end
+
+  -- extra_linters is a function of the buffer; the GitHub Actions branch keys
+  -- off the buffer name, so ask it with a path that takes that branch too.
+  local probe = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_name(probe, "/tmp/.github/workflows/probe.yaml")
+
+  for _, name in ipairs(lint_opts.extra_linters(probe)) do
+    add(name, "linter", "yaml")
+  end
+
+  vim.api.nvim_buf_delete(probe, { force = true })
+
+  table.sort(tools, function(a, b)
+    return a.name < b.name
+  end)
+
+  return tools
+end
+
+---@param filetype string
+---@return string filename, string content
+local function sample_for(filetype)
+  local ext = EXTENSIONS[filetype] or filetype
+  local filename = ext:match("^%u") and ext or ("sample." .. ext)
+
+  return filename, SAMPLES[filetype] or "\n"
+end
+
+--- Resolve the argv this config would actually run for `tool`.
+---@param tool table
+---@param filepath string
+---@param bufnr integer
+---@return string[]|nil argv, string|nil err
+local function resolve_argv(tool, filepath, bufnr)
+  if tool.kind == "formatter" then
+    local config = conform.get_formatter_config(tool.name, bufnr)
+
+    if not config then
+      return nil, "no formatter config"
+    end
+
+    if config.format then
+      return nil, "lua formatter, runs in-process"
+    end
+
+    local ctx = {
+      buf = bufnr,
+      filename = filepath,
+      dirname = vim.fs.dirname(filepath),
+    }
+
+    local ok, argv = pcall(runner.build_cmd, tool.name, ctx, config)
+
+    return ok and argv or nil, ok and nil or tostring(argv)
+  end
+
+  local linter = lint.linters[tool.name]
+
+  -- A few built-in definitions are functions that build the linter per call;
+  -- there is no static argv to inspect for those.
+  if type(linter) ~= "table" then
+    return nil, "no static linter definition"
+  end
+
+  local cmd = linter.cmd
+
+  if type(cmd) == "function" then
+    local ok, resolved = pcall(cmd)
+
+    if not ok then
+      return nil, "cmd() failed"
+    end
+
+    cmd = resolved
+  end
+
+  local argv = { cmd }
+
+  for _, arg in ipairs(linter.args or {}) do
+    if type(arg) == "function" then
+      local ok, resolved = pcall(arg)
+
+      if not ok then
+        return nil, "arg() failed"
+      end
+
+      arg = resolved
+    end
+
+    -- An arg function may return a list, or nil to drop itself.
+    if type(arg) == "table" then
+      vim.list_extend(argv, arg)
+    elseif arg ~= nil then
+      table.insert(argv, tostring(arg))
+    end
+  end
+
+  return argv
+end
+
+---@param dir string
+---@return string[]
+local function entries_in(dir)
+  local names = {}
+
+  for name in vim.fs.dir(dir) do
+    table.insert(names, name)
+  end
+
+  table.sort(names)
+
+  return names
+end
+
+-- Optional positional arguments narrow the run to the named tools. `nvim -l`
+-- leaves them in v:argv after the script path rather than in argv().
+local only = {}
+
+do
+  local argv = vim.v.argv
+  local script_index
+
+  for i, value in ipairs(argv) do
+    if value:match("check%-tool%-litter%.lua$") then
+      script_index = i
+      break
+    end
+  end
+
+  for i = (script_index or #argv) + 1, #argv do
+    only[argv[i]] = true
+  end
+end
+
+local tools = collect_tools()
+local littered = {}
+local skipped = {}
+local checked = 0
+
+for _, tool in ipairs(tools) do
+  if next(only) == nil or only[tool.name] then
+    local dir = vim.fn.tempname()
+    vim.fn.mkdir(dir, "p")
+
+    local filename, content = sample_for(tool.filetype)
+    local filepath = dir .. "/" .. filename
+    local before = { [filename] = true }
+
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_name(bufnr, filepath)
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.split(content, "\n"))
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.fn.writefile(vim.split(content, "\n", { trimempty = true }), filepath)
+
+    local argv, err = resolve_argv(tool, filepath, bufnr)
+
+    if argv and vim.fn.executable(argv[1]) == 1 then
+      checked = checked + 1
+
+      pcall(function()
+        vim
+          .system(argv, {
+            cwd = dir,
+            stdin = content,
+            text = true,
+            timeout = TIMEOUT_MS,
+          })
+          :wait()
+      end)
+
+      local leftovers = vim.tbl_filter(function(name)
+        return not before[name]
+      end, entries_in(dir))
+
+      if #leftovers > 0 then
+        table.insert(littered, {
+          name = tool.name,
+          kind = tool.kind,
+          entries = leftovers,
+        })
+      end
+    else
+      table.insert(skipped, {
+        name = tool.name,
+        reason = err or "not installed",
+      })
+    end
+
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+    vim.fn.delete(dir, "rf")
+  end
+end
+
+if #littered > 0 then
+  print("LITTER - these tools wrote into the working directory:")
+  print("")
+
+  for _, entry in ipairs(littered) do
+    print(("  %-24s (%s)  %s"):format(entry.name, entry.kind, table.concat(entry.entries, ", ")))
+  end
+
+  print("")
+  print("Point each one at a cache directory outside the cwd, or disable its cache.")
+  print("Both are per-tool: a CLI flag via `append_args`, or an env var in lua/config/.")
+end
+
+print("")
+print(("checked %d tool(s), skipped %d (not installed or no resolvable argv)"):format(checked, #skipped))
+
+if os.getenv("CHECK_TOOL_LITTER_VERBOSE") then
+  for _, entry in ipairs(skipped) do
+    print(("  skipped %-24s %s"):format(entry.name, entry.reason))
+  end
+end
+
+os.exit(#littered > 0 and 1 or 0)

--- a/scripts/check-tool-litter.sh
+++ b/scripts/check-tool-litter.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-tool-litter.sh - Find formatters and linters that write into the working
+# directory.
+#
+# Runnable from anywhere: the script cds into the Neovim config repository root
+# (the parent of this script's directory) before scanning, so the
+# lua/plugins/**/opts.lua paths resolve regardless of the caller's working
+# directory.
+#
+# It delegates the actual check to check-tool-litter.lua, executed with
+# `nvim --headless -l`. The Lua checker resolves the exact argv this config
+# would run for every configured formatter and linter, runs each one inside a
+# fresh empty directory, and reports anything left behind. Tools are supposed to
+# keep caches under XDG_CACHE_HOME or a temp directory; the ones that default to
+# the cwd instead are only discoverable by running them and looking.
+#
+# Usage:
+#   scripts/check-tool-litter.sh            # every configured tool
+#   scripts/check-tool-litter.sh rumdl ruff # only the named tools
+#
+# Set CHECK_TOOL_LITTER_VERBOSE=1 to also list which tools were skipped and why.
+#
+# Exit code: 0 when nothing littered, 1 when any tool did.
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_ROOT="$(dirname "${SCRIPT_DIR}")"
+
+cd "${REPO_ROOT}"
+
+exec nvim --headless -l "${SCRIPT_DIR}/check-tool-litter.lua" "$@"


### PR DESCRIPTION
## 問題

Markdown を保存すると cwd に `.rumdl_cache/` が生成される。**以前 conform 側で直したはずのものが再発していた。**

原因は conform ではなく nvim-lint。`markdown = { "rumdl" }` を `BufWritePost` で走らせているが、conform 側にある `--no-cache` がこちらに無かった。conform の `BufWritePre` フォーマット直後に必ず走るため、「format したあとに出る」ように見えていた。

調査の過程で別のバグも見つかった。nvim-lint 同梱の rumdl 定義は `stream = "stderr"` だが、rumdl は JSON を **stdout** に出す。**markdown の lint は一度も動いておらず、エラーも警告も出ずに診断ゼロだった**（rumdl 0.2.52 で確認）。

## 解決策

`--no-cache` を足すだけでは同じことがまた起きる。記入箇所が「ツール数 × 呼び出し経路数」になっており、rumdl だけで conform / nvim-lint / LSP の3経路ある。今回漏れたのが2経路目で、3経路目は空欄のままだった。そこで3段構えにした。

1. **`fix(nvim-lint)` 2件** — 目の前の再発と、それに隠れていた stdout バグを直す。`stream` を上書きするため、override ループが `append_args` 以外のキーも扱えるように一般化した。
2. **`feat(scripts)` — `task check-tool-litter`（別名 `ctl`）** — 設定済みの全ツールを空の一時ディレクトリで実際に走らせ、cwd に何を残すかを報告する。行儀の悪さは設定からは読めず、走らせて見るしかない。argv の解決は conform 自身の `build_cmd` と、切り出した `plugins.nvim-lint.apply_overrides` を経由するので、**監査結果とエディタの実挙動がずれない。**
3. **`fix(config)` — `lua/config/tool_cache.lua`** — `RUMDL_CACHE_DIR` をプロセス環境で1度だけ設定し、LSP を含む**3経路すべて**を覆う。引数層の N×M を消す。

## 検証

| 確認 | 結果 |
|---|---|
| `task ctl` 全スイープ | 29件チェック、litter ゼロ |
| 負のコントロール（`--no-cache` を外す） | `rumdl (formatter) .rumdl_cache` を検知 |
| `RUMDL_CACHE_DIR` あり／なし | なし→cwd に生成、あり→cwd はきれいで指定先に生成 |
| headless で lint 実行 | `MD022: Expected 1 blank line below heading` を1件取得（修正前はゼロ） |
| 既存 `typos` の override | 一般化後も argv 不変 |

stylua / selene ともにクリーン。

## 限界

`check-tool-litter` のサンプルは1行なので、実プロジェクト規模でキャッシュミス時にだけ書くツールは静かに通り得る。スクリプト冒頭にもその旨を書いてある。
