### PR TITLE
feat(scripts): inventory add/* branches stuck at vendoring

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -129,3 +129,11 @@ tasks:
     cmds:
       - "{{.TASKFILE_DIR}}/scripts/check-tool-litter.sh {{.CLI_ARGS}}"
     silent: true
+
+  check-vendor-stalled:
+    desc: "List remote add/* branches still stuck at the vendor-only stage"
+    aliases:
+      - cvs
+    cmds:
+      - "{{.TASKFILE_DIR}}/scripts/check-vendor-stalled.sh {{.CLI_ARGS}}"
+    silent: true

--- a/docs/vendor-stalled-branches.md
+++ b/docs/vendor-stalled-branches.md
@@ -1,0 +1,246 @@
+# vendoring 停止ブランチの棚卸し
+
+`origin/add/*` のうち、`add-plugin` の vendoring だけ済んで spec が未記入のまま
+止まっているブランチを機械的に判定するための資料。判定スクリプトは
+`scripts/check-vendor-stalled.sh`。
+
+## 背景
+
+`add-plugin` スキルは既定で **vendor-only** モードで動く。1 プラグインにつき
+`add/<dir-name>` ブランチを切り、次を積んで**そこで止まる**。
+
+- 空の marker コミット `feat: add <owner>/<repo>`
+- `lua/<tree>/<dir-name>/CODES/`（および wiki があれば `WIKIS/`）— "wip" コミット
+- lazy.nvim の spec テンプレート — `TODO: it` マーカーが入ったまま、"wip" コミット
+
+`--fill` を通すと spec が埋まり、wip コミットが 1 つの `feat:` に squash される。
+vendoring だけして後回しにしたブランチが積み上がり、**ブランチ名からは
+どこまで進んだのか分からない**。2026-08-09 時点で `origin/add/*` は 146 本ある。
+
+## 判定ロジック
+
+`origin/master..<branch>` に対して 2 つの数を取る。
+
+- **todo** — このブランチが追加した `.lua` のうち、`CODES/` と `WIKIS/` 配下を除いて
+  `TODO: it` を含むファイル数。**spec が未記入**であることの印
+- **wip** — コミット subject がちょうど `wip` のものの数。**squash 前**であることの印
+
+この 2 つで 4 分類する。
+
+| 分類 | 条件 | 意味 | 残作業 |
+|---|---|---|---|
+| **A** | todo > 0, wip > 0 | vendoring したまま停止 | spec を埋める → 検証 → squash |
+| **B** | todo > 0, wip = 0 | 埋める前に squash された | spec を埋める |
+| **C** | todo = 0, wip > 0 | spec 済み・squash 前 | 検証 → squash |
+| **D** | todo = 0, wip = 0 | 完了形 | なし（マージ待ち） |
+
+vendored な `CODES/`・`WIKIS/` を除外するのが要点。プラグイン本体のソースにも
+`TODO` は当たり前に含まれるので、除外しないと全部 A になる。
+
+## 使い方
+
+```bash
+task cvs                      # 分類 A を新しい順に一覧（既定）
+task cvs -- --class C         # 分類 C だけ
+task cvs -- --class all       # 全 146 本
+task cvs -- --names           # ブランチ名だけ（パイプ用）
+task cvs -- --fetch           # remote refs を更新してから判定
+```
+
+出力は 1 行 1 ブランチで、末尾に必ず 4 分類の件数サマリが付く。
+
+```text
+2026-08-02  add/catppuccin-nvim                (class=A todo=4 wip=1)
+...
+A stalled at vendoring : 104
+B filled but squashed  : 0
+C spec done, no squash : 22
+D finished shape       : 20
+total                  : 146
+```
+
+`--names` は他コマンドへ渡す用。
+
+```bash
+task cvs -- --class C --names | while read -r b; do
+  git log --oneline "origin/master..origin/$b"
+done
+```
+
+**exit code は常に 0。** これは lint ではなく棚卸しで、該当ブランチが存在するのは
+正常な状態だから。CI のゲートには使わない。
+
+その他のオプションは `scripts/check-vendor-stalled.sh --help`。
+`--base` / `--remote` で比較対象を変えられる。
+
+### なぜ一発のシェルコマンドではなくスクリプトなのか
+
+同じ判定を Bash ツール上で直接パイプで書くと、`rtk` フックが `git` の出力を
+要約・改変するため、`git diff --name-only` のファイル一覧が壊れる。実際にこれで
+**全ブランチが todo=0 という誤った結果**が出た（`Changes:` のような要約行が
+ファイル名として混ざった）。`bash <script>` 経由なら git の出力はそのまま渡る。
+判定をファイルに固定してあるのはこの理由による。
+
+## スナップショット（2026-08-09 時点）
+
+> **この節は古くなる。** 最新の状態は `task cvs` を実行して得ること。
+> ここに残しているのは、後から「いつ時点で何本あったか」を辿るため。
+
+### A: vendoring したまま停止（104 本）
+
+```text
+2026-08-02  add/atlas-nvim                     (class=A todo=2 wip=1)
+2026-08-02  add/catppuccin-nvim                (class=A todo=4 wip=1)
+2026-08-02  add/cyberdream-nvim                (class=A todo=4 wip=1)
+2026-08-02  add/dracula-vim                    (class=A todo=4 wip=1)
+2026-08-02  add/everforest-nvim                (class=A todo=4 wip=1)
+2026-08-02  add/github-nvim-theme              (class=A todo=4 wip=1)
+2026-08-02  add/gruvbox-nvim                   (class=A todo=4 wip=1)
+2026-08-02  add/kanagawa-nvim                  (class=A todo=4 wip=1)
+2026-08-02  add/kanagawa-paper-nvim            (class=A todo=4 wip=1)
+2026-08-02  add/monokai-pro-nvim               (class=A todo=4 wip=1)
+2026-08-02  add/nightfox-nvim                  (class=A todo=4 wip=1)
+2026-08-02  add/nvim-pio                       (class=A todo=4 wip=1)
+2026-08-02  add/onedarkpro-nvim                (class=A todo=4 wip=1)
+2026-08-02  add/oxocarbon-nvim                 (class=A todo=4 wip=1)
+2026-08-02  add/pi2-nvim                       (class=A todo=4 wip=1)
+2026-08-02  add/rose-pine-neovim               (class=A todo=1 wip=1)
+2026-08-02  add/sonokai                        (class=A todo=4 wip=1)
+2026-08-02  add/swapson-nvim                   (class=A todo=4 wip=1)
+2026-08-02  add/termfile-nvim                  (class=A todo=4 wip=1)
+2026-08-02  add/vague-nvim                     (class=A todo=4 wip=1)
+2026-08-02  add/vim-matchup                    (class=A todo=4 wip=1)
+2026-08-02  add/visual-multi-nvim              (class=A todo=4 wip=1)
+2026-07-26  add/grug-far-nvim                  (class=A todo=2 wip=1)
+2026-07-26  add/jujutsu-nvim                   (class=A todo=2 wip=1)
+2026-07-26  add/nerdtree                       (class=A todo=3 wip=1)
+2026-07-26  add/vim-fern                       (class=A todo=3 wip=1)
+2026-07-25  add/nvim-deck                      (class=A todo=4 wip=5)
+2026-07-25  add/nvim-insx                      (class=A todo=4 wip=1)
+2026-07-24  add/nvim-aibo                      (class=A todo=3 wip=1)
+2026-07-24  add/searchbox-nvim                 (class=A todo=3 wip=5)
+2026-07-20  add/cmake-tools-nvim               (class=A todo=2 wip=1)
+2026-07-20  add/codesettings-nvim              (class=A todo=1 wip=9)
+2026-07-20  add/elixir-tools-nvim              (class=A todo=4 wip=5)
+2026-07-20  add/flutter-tools-nvim             (class=A todo=4 wip=5)
+2026-07-20  add/go-nvim                        (class=A todo=4 wip=9)
+2026-07-20  add/haskell-tools-nvim             (class=A todo=4 wip=7)
+2026-07-20  add/kotlin-nvim                    (class=A todo=3 wip=8)
+2026-07-20  add/laravel-nvim                   (class=A todo=3 wip=4)
+2026-07-20  add/lean-nvim                      (class=A todo=4 wip=12)
+2026-07-20  add/nvim-java                      (class=A todo=3 wip=9)
+2026-07-20  add/nvim-jdtls                     (class=A todo=3 wip=8)
+2026-07-20  add/nvim-metals                    (class=A todo=3 wip=10)
+2026-07-20  add/pymple-nvim                    (class=A todo=2 wip=8)
+2026-07-20  add/roslyn-nvim                    (class=A todo=4 wip=4)
+2026-07-20  add/typescript-tools-nvim          (class=A todo=2 wip=1)
+2026-07-19  add/powershell-nvim                (class=A todo=1 wip=1)
+2026-07-19  add/rustaceanvim                   (class=A todo=3 wip=1)
+2026-07-18  add/keeper-nvim                    (class=A todo=4 wip=1)
+2026-07-18  add/neojj                          (class=A todo=4 wip=1)
+2026-07-18  add/tasks-nvim                     (class=A todo=4 wip=1)
+2026-07-17  add/render-markdown-nvim           (class=A todo=9 wip=1)
+2026-07-14  add/fzf-lua                        (class=A todo=4 wip=1)
+2026-07-14  add/fzf-oil-nvim                   (class=A todo=4 wip=1)
+2026-07-14  add/yankdown-nvim                  (class=A todo=4 wip=1)
+2026-07-13  add/diffs-nvim                     (class=A todo=4 wip=1)
+2026-07-13  add/vim-fugitive                   (class=A todo=4 wip=1)
+2026-07-10  add/camouflage-nvim                (class=A todo=2 wip=1)
+2026-07-10  add/wind-nvim                      (class=A todo=1 wip=1)
+2026-06-30  add/harpoon                        (class=A todo=1 wip=8)
+2026-06-30  add/kulala-nvim                    (class=A todo=3 wip=13)
+2026-06-30  add/refactoring-nvim               (class=A todo=2 wip=6)
+2026-06-29  add/juu-nvim                       (class=A todo=2 wip=5)
+2026-06-24  add/jj-nvim                        (class=A todo=2 wip=1)
+2026-06-21  add/neominimap-nvim                (class=A todo=4 wip=3)
+2026-06-19  add/blink-cmp                      (class=A todo=2 wip=1)
+2026-06-19  add/codewindow-nvim                (class=A todo=2 wip=1)
+2026-06-19  add/minimap-vim                    (class=A todo=2 wip=1)
+2026-06-19  add/mini-nvim                      (class=A todo=4 wip=1)
+2026-06-19  add/nvim-autopairs                 (class=A todo=3 wip=1)
+2026-06-19  add/nvim-cmp                       (class=A todo=2 wip=1)
+2026-05-19  add/neo-tree-nvim                  (class=A todo=1 wip=18)
+2026-05-15  add/codedocs-nvim                  (class=A todo=3 wip=1)
+2026-05-15  add/hydra-nvim                     (class=A todo=3 wip=7)
+2026-05-15  add/neotest                        (class=A todo=2 wip=1)
+2026-05-15  add/nvim-neorg                     (class=A todo=3 wip=1)
+2026-05-15  add/nvim-orgmode                   (class=A todo=3 wip=3)
+2026-05-15  add/nvim-tree-lua                  (class=A todo=1 wip=1)
+2026-05-15  add/zk-nvim                        (class=A todo=1 wip=1)
+2026-05-14  add/none-ls-nvim                   (class=A todo=1 wip=1)
+2026-05-12  add/lspsaga-nvim                   (class=A todo=1 wip=1)
+2026-05-12  add/multiple-cursors-nvim          (class=A todo=2 wip=6)
+2026-05-11  add/multicursors-nvim              (class=A todo=1 wip=1)
+2026-05-05  add/nvim-hlslens                   (class=A todo=4 wip=3)
+2026-05-05  add/project-nvim                   (class=A todo=1 wip=2)
+2026-05-05  add/vim-quickrun                   (class=A todo=3 wip=3)
+2026-05-04  add/helpview-nvim                  (class=A todo=4 wip=6)
+2026-05-03  add/diffview-nvim                  (class=A todo=1 wip=1)
+2026-05-03  add/nvim-bqf                       (class=A todo=4 wip=2)
+2026-05-03  add/nvim-ufo                       (class=A todo=4 wip=2)
+2026-05-03  add/toggleterm-nvim                (class=A todo=3 wip=8)
+2026-05-02  add/skkeleton                      (class=A todo=3 wip=7)
+2026-05-02  add/vim-gin                        (class=A todo=2 wip=1)
+2026-05-01  add/markview-nvim                  (class=A todo=4 wip=1)
+2026-05-01  add/obsidian-nvim                  (class=A todo=1 wip=8)
+2026-05-01  add/vimwiki                        (class=A todo=4 wip=4)
+2026-04-28  add/tiny-code-action-nvim          (class=A todo=1 wip=1)
+2026-04-27  add/octo-nvim                      (class=A todo=1 wip=1)
+2026-04-26  add/dial-nvim                      (class=A todo=2 wip=1)
+2026-04-26  add/lexima-vim                     (class=A todo=2 wip=1)
+2026-04-26  add/noice-nvim                     (class=A todo=4 wip=1)
+2026-04-26  add/nvumi                          (class=A todo=4 wip=1)
+2026-04-26  add/overseer-nvim                  (class=A todo=1 wip=1)
+2026-04-26  add/snacks-nvim                    (class=A todo=3 wip=1)
+2026-04-26  add/telescope-nvim                 (class=A todo=1 wip=1)
+```
+
+### C: spec は埋まっているが squash 前（22 本）
+
+```text
+2026-08-02  add/pastelnight-nvim               (class=C todo=0 wip=1)
+2026-07-26  add/neogit                         (class=C todo=0 wip=16)
+2026-07-20  add/nvim-html-css                  (class=C todo=0 wip=18)
+2026-07-11  add/skkelua-nvim                   (class=C todo=0 wip=1)
+2026-06-21  add/fff-nvim                       (class=C todo=0 wip=1)
+2026-05-15  add/ccc-nvim                       (class=C todo=0 wip=23)
+2026-05-04  add/dashboard-nvim                 (class=C todo=0 wip=1)
+2026-05-04  add/eskk-vim                       (class=C todo=0 wip=1)
+2026-05-04  add/hover-nvim                     (class=C todo=0 wip=1)
+2026-05-04  add/nvim-dap                       (class=C todo=0 wip=1)
+2026-05-04  add/nvim-dap-ui                    (class=C todo=0 wip=1)
+2026-05-04  add/nvim-ts-autotag                (class=C todo=0 wip=1)
+2026-05-04  add/substitute-nvim                (class=C todo=0 wip=1)
+2026-05-04  add/template-nvim                  (class=C todo=0 wip=1)
+2026-05-04  add/translate-nvim                 (class=C todo=0 wip=1)
+2026-05-04  add/wezterm-nvim                   (class=C todo=0 wip=4)
+2026-04-29  add/nvim-surround                  (class=C todo=0 wip=1)
+2026-04-26  add/bento-nvim                     (class=C todo=0 wip=1)
+2026-04-26  add/line-justice-nvim              (class=C todo=0 wip=1)
+2026-04-26  add/pomo-nvim                      (class=C todo=0 wip=1)
+2026-04-26  add/sidekick-nvim                  (class=C todo=0 wip=1)
+2026-04-26  add/solarized-osaka-nvim           (class=C todo=0 wip=1)
+```
+
+### B / D
+
+- **B**: 0 本
+- **D**: 20 本 —
+  `cellwidths-nvim` `droast-nvim` `ferris-nvim` `hamal-nvim` `homegrown-nvim`
+  `mason-tool-installer-nvim` `match-nvim` `matugen-nvim` `neovim-tips`
+  `nvim-dora` `nvim-lsp-endhints` `penguin-nvim` `review-nvim` `rustowl`
+  `scratch-nvim` `squix-nvim` `stickybuf-nvim` `ts-error-translator-nvim`
+  `vim-startuptime` `weborigami-nvim`
+
+## 読み取れること
+
+- **A の 104 本は「1 本ずつ順に消す」対象にすると終わらない。** 生成された塊が
+  そのまま意味の塊になっているので、塊で扱うほうが刻める。
+  - 2026-08-02 の 22 本 — ほぼ全部カラースキーム
+  - 2026-07-20 の 15 本 — 言語ごとの LSP / ツール（`nvim-java`、`nvim-metals`、
+    `haskell-tools-nvim`、`elixir-tools-nvim` など）
+  - それ以外は単発
+- **C の 22 本が一番手離れが近い。** spec は書けているので、読み込み検証と squash
+  だけで D になる。
+- **B が 0 本**なのは、`--fill` が「埋める」と「squash する」を必ずセットで
+  やっているため。B が出てきたら手作業で squash した跡ということになる。

--- a/scripts/check-vendor-stalled.sh
+++ b/scripts/check-vendor-stalled.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-vendor-stalled.sh - List remote add/* branches still stuck at the
+# vendor-only stage of the add-plugin workflow.
+#
+# Runnable from anywhere: the script cds into the Neovim config repository
+# root (the parent of this script's directory) before inspecting refs, so the
+# result does not depend on the caller's working directory.
+#
+# Background:
+#   The add-plugin skill defaults to vendor-only mode. It vendors the plugin
+#   source into <plugin>/CODES (plus WIKIS) and copies lazy.nvim spec
+#   templates whose `TODO: it` markers are left untouched, as a marker commit
+#   plus one or more "wip" commits. Running the skill with --fill afterwards
+#   fills the spec in and squashes the wip commits into a single feat: commit.
+#   Two signals therefore tell the two states apart, per branch:
+#
+#     todo - number of .lua files the branch adds (excluding CODES/ and WIKIS/)
+#            that still contain a `TODO: it` marker  -> spec not filled in
+#     wip  - number of commits whose subject is exactly "wip"
+#            -> not squashed yet
+#
+#   Class  Condition            Meaning
+#     A    todo > 0, wip > 0    stalled at vendoring, nothing done since
+#     B    todo > 0, wip = 0    partially filled but already squashed
+#     C    todo = 0, wip > 0    spec filled in, squash still pending
+#     D    todo = 0, wip = 0    finished shape
+#
+# Usage:
+#   scripts/check-vendor-stalled.sh                  # class A, newest first
+#   scripts/check-vendor-stalled.sh --class C
+#   scripts/check-vendor-stalled.sh --class all
+#   scripts/check-vendor-stalled.sh --names          # branch names only
+#   scripts/check-vendor-stalled.sh --fetch          # refresh remote refs first
+#   task check-vendor-stalled
+#   task cvs -- --class C
+#
+# Options:
+#   --class A|B|C|D|all   Which class to list (default: A)
+#   --names               Print bare branch names, one per line (pipe-friendly)
+#   --fetch               Run `git fetch --prune <remote>` before inspecting
+#   --base <ref>          Base ref to diff against (default: master)
+#   --remote <name>       Remote to inspect (default: origin)
+#   -h, --help            Show this help
+#
+# Exit code: always 0 on success. This is an inventory, not a lint; branches
+# being stalled is the normal state and must not fail a task pipeline.
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_ROOT="$(dirname "${SCRIPT_DIR}")"
+
+cd "${REPO_ROOT}"
+
+# Usage: usage
+# Description: Print the Usage/Options block of this file's header comment.
+# Returns: always 0
+usage() {
+    awk '/^readonly SCRIPT_DIR=/ { exit }
+         /^# Usage:/ { show = 1 }
+         show { sub(/^# ?/, ""); print }' "${BASH_SOURCE[0]}"
+}
+
+class_filter="A"
+names_only=0
+do_fetch=0
+base="master"
+remote="origin"
+
+while (($# > 0)); do
+    case "$1" in
+        --class)
+            class_filter="${2:?Error: --class requires a value}"
+            shift 2
+            ;;
+        --class=*)
+            class_filter="${1#--class=}"
+            shift
+            ;;
+        --names)
+            names_only=1
+            shift
+            ;;
+        --fetch)
+            do_fetch=1
+            shift
+            ;;
+        --base)
+            base="${2:?Error: --base requires a value}"
+            shift 2
+            ;;
+        --base=*)
+            base="${1#--base=}"
+            shift
+            ;;
+        --remote)
+            remote="${2:?Error: --remote requires a value}"
+            shift 2
+            ;;
+        --remote=*)
+            remote="${1#--remote=}"
+            shift
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+case "${class_filter}" in
+    A | B | C | D | all) ;;
+    *)
+        echo "Error: --class must be one of A, B, C, D, all (got: ${class_filter})" >&2
+        exit 2
+        ;;
+esac
+
+if ((do_fetch)); then
+    git fetch --prune "${remote}" >/dev/null 2>&1 ||
+        echo "Warning: git fetch --prune ${remote} failed; using cached refs" >&2
+fi
+
+readonly base_ref="${remote}/${base}"
+
+if ! git rev-parse --verify --quiet "${base_ref}" >/dev/null; then
+    echo "Error: base ref not found: ${base_ref}" >&2
+    exit 2
+fi
+
+# Usage: classify_branch <full-ref>
+# Description: Echo "<class>\t<short-name>\t<date>\t<todo>\t<wip>" for one branch.
+classify_branch() {
+    local ref="${1:?Error: ref required}"
+    local todo=0 wip=0 file class
+
+    while IFS= read -r file; do
+        case "${file}" in
+            */CODES/* | */WIKIS/*) continue ;;
+            *.lua) ;;
+            *) continue ;;
+        esac
+        if git show "${ref}:${file}" 2>/dev/null | grep -q 'TODO: it'; then
+            todo=$((todo + 1))
+        fi
+    done < <(git diff --name-only "${base_ref}...${ref}")
+
+    wip=$(git log --format='%s' "${base_ref}..${ref}" | grep -c '^wip$' || true)
+
+    if ((todo > 0)); then
+        ((wip > 0)) && class="A" || class="B"
+    else
+        ((wip > 0)) && class="C" || class="D"
+    fi
+
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+        "${class}" \
+        "${ref#"${remote}"/}" \
+        "$(git log -1 --format='%cs' "${ref}")" \
+        "${todo}" \
+        "${wip}"
+}
+
+rows=""
+while IFS= read -r ref; do
+    rows+="$(classify_branch "${ref}")"$'\n'
+done < <(git for-each-ref --format='%(refname:short)' "refs/remotes/${remote}/add")
+
+if [[ -z "${rows//[$'\n\t ']/}" ]]; then
+    echo "No ${remote}/add/* branches found." >&2
+    exit 0
+fi
+
+# Selected rows, newest commit first.
+selected=$(printf '%s' "${rows}" | awk -F'\t' -v c="${class_filter}" \
+    'NF && (c == "all" || $1 == c)' | sort -t$'\t' -k3,3r -k2,2)
+
+if ((names_only)); then
+    printf '%s' "${selected}" | awk -F'\t' 'NF {print $2}'
+    exit 0
+fi
+
+if [[ -n "${selected//[$'\n\t ']/}" ]]; then
+    printf '%s' "${selected}" |
+        awk -F'\t' 'NF {printf "%s  %-34s (class=%s todo=%s wip=%s)\n", $3, $2, $1, $4, $5}'
+else
+    echo "(no branches in class ${class_filter})"
+fi
+
+printf '\n'
+printf '%s' "${rows}" | awk -F'\t' '
+NF { n[$1]++; total++ }
+END {
+    printf "A stalled at vendoring : %d\n", n["A"]
+    printf "B filled but squashed  : %d\n", n["B"]
+    printf "C spec done, no squash : %d\n", n["C"]
+    printf "D finished shape       : %d\n", n["D"]
+    printf "total                  : %d\n", total
+}'


### PR DESCRIPTION
## 問題

`origin/add/*` が 146 本たまり、ブランチ名からは進捗が分からなくなっていた。
`add-plugin` は既定で vendor-only モードで止まるため、「vendoring しただけ」の
ブランチと「spec まで書いたブランチ」が混ざっている。目視では区別できない。

## 解決

`origin/master..<branch>` の 2 つの信号で機械的に分類する。

- **todo** — そのブランチが追加した `.lua`（`CODES/`・`WIKIS/` 配下は除く）のうち
  `TODO: it` が残っている数 → spec 未記入
- **wip** — subject がちょうど `wip` のコミット数 → squash 前

| 分類 | 条件 | 意味 | 件数 |
|---|---|---|---|
| A | todo>0, wip>0 | vendoring したまま停止 | 104 |
| B | todo>0, wip=0 | 埋める前に squash | 0 |
| C | todo=0, wip>0 | spec 済み・squash 前 | 22 |
| D | todo=0, wip=0 | 完了形 | 20 |

vendored な `CODES/`・`WIKIS/` を除外するのが要点。プラグイン本体のソースにも
`TODO` は普通に入っているので、除外しないと全件が A になる。

## 変更

- `scripts/check-vendor-stalled.sh` — 純 git + bash（nvim 起動不要、実行 3 秒）。
  `--class A|B|C|D|all` / `--names` / `--fetch` / `--base` / `--remote`。
  棚卸しであって lint ではないので exit code は常に 0
- `Taskfile.yml` — `task check-vendor-stalled`（別名 `task cvs`）
- `docs/vendor-stalled-branches.md` — 背景・判定ロジック・使い方・2026-08-09 の
  スナップショット全件

## 検証

- `task cvs` → A=104 / B=0 / C=22 / D=20 / total=146
- `--class C`, `--class all`, `--names`, `--class=D` の各形式が一致
- `/tmp` から絶対パス実行しても同結果（`REPO_ROOT` への cd が効いている）
- 不正な `--class Z` は exit 2
- shellcheck: 既存 `check-*.sh` と同じ SC2155 のみ / shfmt 差分なし / rumdl clean
- `task check-keys` は引き続き通る（Taskfile を壊していない）