### PR TITLE
fix(scripts): lowercase vendored plugin directory names

### DIFF
--- a/.claude/skills/add-plugin/SKILL.md
+++ b/.claude/skills/add-plugin/SKILL.md
@@ -87,7 +87,7 @@ Throughout the rest of this document `<tree>` means the chosen directory name.
 - The script prints `INFO: target <dir> -> spec template <name>`. **Check that
   line** — it confirms the tree actually in use before any cloning happens.
 - For each URL the script creates a branch `add/<dir-name>`
-  (`<dir-name>` = repo name with `.` → `-`, e.g. `convy.nvim` → `convy-nvim`)
+  (`<dir-name>` = repo name lowercased with `.` → `-`, e.g. `Otree.nvim` → `otree-nvim`)
   containing:
   - an empty marker commit `feat: add <owner>/<repo>`
   - `lua/<tree>/<dir-name>/CODES/` — the plugin source, history stripped ("wip" commit)

--- a/scripts/nvim-plugin-clone.sh
+++ b/scripts/nvim-plugin-clone.sh
@@ -127,6 +127,9 @@ process_plugin() {
     fi
     dir_name="${owner_repo##*/}"
     dir_name="${dir_name//./-}"
+    # Upstream repo names are not consistently lowercase (e.g. Otree.nvim), but
+    # every plugin directory and require() path in this config is.
+    dir_name="${dir_name,,}"
     clone_url="${base}.git"
     wiki_url="${base}.wiki.git"
     branch="add/${dir_name}"


### PR DESCRIPTION
## Problem

`scripts/nvim-plugin-clone.sh` derived the plugin directory name from the
upstream repo name, replacing `.` with `-` but keeping the original case.
Upstream names are not consistently lowercase, so vendoring
`Eutrius/Otree.nvim` produced `lua/plugins/Otree-nvim/` and a branch
`add/Otree-nvim`, while every other plugin directory and `require()` path in
this config is lowercase.

## Solution

Lowercase `dir_name` after the `.` → `-` replacement. The branch name is
derived from the same variable, so it is fixed as well. `clone_url` is built
from `owner_repo`, not `dir_name`, so the fetch target is unaffected.

`SKILL.md` documents the naming rule, so its description and example are
updated to match.

## Verification

- `bash -n` and `shellcheck` pass
- Derivation checked directly: `Eutrius/Otree.nvim` → `otree-nvim`,
  `piersolenski/brewfile.nvim` → `brewfile-nvim`,
  `folke/tokyonight.nvim` → `tokyonight-nvim` (already-lowercase repos
  are unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)