### PR TITLE
fix(keys): fill empty keymap desc and lint for it

### DIFF
--- a/lua/plugins/aerial-nvim/keys.lua
+++ b/lua/plugins/aerial-nvim/keys.lua
@@ -8,7 +8,7 @@ local keys = {
     mode = {
       "n",
     },
-    desc = "",
+    desc = "Aerial: toggle outline",
     silent = true,
   },
 }

--- a/lua/plugins/cord-nvim/keys.lua
+++ b/lua/plugins/cord-nvim/keys.lua
@@ -8,7 +8,7 @@ local keys = {
     mode = {
       "n",
     },
-    desc = "",
+    desc = "Cord: toggle presence",
     silent = true,
   },
   {
@@ -19,7 +19,7 @@ local keys = {
     mode = {
       "n",
     },
-    desc = "",
+    desc = "Cord: toggle idle (force)",
     silent = true,
   },
 }

--- a/lua/plugins/crates-nvim/keys.lua
+++ b/lua/plugins/crates-nvim/keys.lua
@@ -8,7 +8,7 @@ local keys = {
     mode = {
       "n",
     },
-    desc = "",
+    desc = "Crates: toggle",
     silent = true,
   },
   {
@@ -19,7 +19,7 @@ local keys = {
     mode = {
       "n",
     },
-    desc = "",
+    desc = "Crates: reload",
     silent = true,
   },
   {
@@ -30,7 +30,7 @@ local keys = {
     mode = {
       "n",
     },
-    desc = "",
+    desc = "Crates: show versions popup",
     silent = true,
   },
   {
@@ -41,7 +41,7 @@ local keys = {
     mode = {
       "n",
     },
-    desc = "",
+    desc = "Crates: show features popup",
     silent = true,
   },
   {
@@ -52,7 +52,7 @@ local keys = {
     mode = {
       "n",
     },
-    desc = "",
+    desc = "Crates: show dependencies popup",
     silent = true,
   },
   {
@@ -63,7 +63,7 @@ local keys = {
     mode = {
       "n",
     },
-    desc = "",
+    desc = "Crates: update crate",
     silent = true,
   },
   {
@@ -74,7 +74,7 @@ local keys = {
     mode = {
       "v",
     },
-    desc = "",
+    desc = "Crates: update selected crates",
     silent = true,
   },
   {
@@ -85,7 +85,7 @@ local keys = {
     mode = {
       "n",
     },
-    desc = "",
+    desc = "Crates: update all crates",
     silent = true,
   },
   {
@@ -96,7 +96,7 @@ local keys = {
     mode = {
       "n",
     },
-    desc = "",
+    desc = "Crates: upgrade crate",
     silent = true,
   },
   {
@@ -107,7 +107,7 @@ local keys = {
     mode = {
       "v",
     },
-    desc = "",
+    desc = "Crates: upgrade selected crates",
     silent = true,
   },
   {
@@ -118,7 +118,7 @@ local keys = {
     mode = {
       "n",
     },
-    desc = "",
+    desc = "Crates: upgrade all crates",
     silent = true,
   },
   {
@@ -129,7 +129,7 @@ local keys = {
     mode = {
       "n",
     },
-    desc = "",
+    desc = "Crates: expand plain crate to inline table",
     silent = true,
   },
   {
@@ -140,7 +140,7 @@ local keys = {
     mode = {
       "n",
     },
-    desc = "",
+    desc = "Crates: extract crate into table",
     silent = true,
   },
   {
@@ -151,7 +151,7 @@ local keys = {
     mode = {
       "n",
     },
-    desc = "",
+    desc = "Crates: open homepage",
     silent = true,
   },
   {
@@ -162,7 +162,7 @@ local keys = {
     mode = {
       "n",
     },
-    desc = "",
+    desc = "Crates: open repository",
     silent = true,
   },
   {
@@ -173,7 +173,7 @@ local keys = {
     mode = {
       "n",
     },
-    desc = "",
+    desc = "Crates: open documentation",
     silent = true,
   },
   {
@@ -184,7 +184,7 @@ local keys = {
     mode = {
       "n",
     },
-    desc = "",
+    desc = "Crates: open crates.io",
     silent = true,
   },
   {
@@ -195,7 +195,7 @@ local keys = {
     mode = {
       "n",
     },
-    desc = "",
+    desc = "Crates: open lib.rs",
     silent = true,
   },
 }

--- a/lua/plugins/vim-illuminate/keys.lua
+++ b/lua/plugins/vim-illuminate/keys.lua
@@ -30,7 +30,7 @@ local keys = {
     mode = {
       "o",
     },
-    desc = "",
+    desc = "Illuminate: select reference textobject",
     silent = true,
   },
   {
@@ -41,7 +41,7 @@ local keys = {
     mode = {
       "x",
     },
-    desc = "",
+    desc = "Illuminate: select reference textobject",
     silent = true,
   },
 }

--- a/lua/plugins/yankbank-nvim/keys.lua
+++ b/lua/plugins/yankbank-nvim/keys.lua
@@ -6,6 +6,7 @@ local keys = {
     mode = {
       "n",
     },
+    desc = "YankBank: open",
     noremap = true,
     silent = true,
   },

--- a/lua/plugins/yanky-nvim/keys.lua
+++ b/lua/plugins/yanky-nvim/keys.lua
@@ -146,7 +146,7 @@ local keys = {
       "o",
       "x",
     },
-    desc = "",
+    desc = "Yanky: last put textobject",
     silent = true,
   },
 }

--- a/scripts/check-keys-spec.lua
+++ b/scripts/check-keys-spec.lua
@@ -23,9 +23,18 @@
 --   string or function, so a positional table is always the nested-opts bug and
 --   never a false positive, regardless of formatting or comments.
 --
+--   The linter also requires every entry to carry a non-empty `desc`. Without it
+--   the mapping shows up unlabelled in which-key, :map and keymap pickers. The
+--   plugin template ships `desc = ""`, so this is easy to leave behind.
+--   Entries whose lhs is still the template placeholder are skipped: the plugin
+--   itself is not configured yet, so there is nothing to describe.
+--
 -- Exit code: 0 when clean, 1 when any violation is found or a file fails to load.
 
 local GLOB = "lua/**/keys.lua"
+
+-- lhs written by the plugin template; such an entry is not filled in yet.
+local PLACEHOLDER_LHS = "<lhs>"
 
 --- Scan a single keys.lua file for nested-opts violations.
 ---@param path string Path to a keys.lua file, relative to cwd.
@@ -42,12 +51,17 @@ local function scan(path)
 
   local violations = {}
   for i, entry in ipairs(spec) do
-    if type(entry) == "table" then
+    if type(entry) == "table" and entry[1] ~= PLACEHOLDER_LHS then
+      local lhs = tostring(entry[1])
       for k, v in pairs(entry) do
         if type(k) == "number" and k >= 2 and type(v) == "table" then
-          local lhs = tostring(entry[1])
           table.insert(violations, string.format("entry #%d (%s): nested opts table at positional index %d", i, lhs, k))
         end
+      end
+      if entry.desc == nil then
+        table.insert(violations, string.format("entry #%d (%s): missing desc", i, lhs))
+      elseif entry.desc == "" then
+        table.insert(violations, string.format("entry #%d (%s): empty desc", i, lhs))
       end
     end
   end
@@ -78,8 +92,10 @@ if total_violations > 0 or total_errors > 0 then
   io.stderr:write(
     string.format(
       "\n%d violation(s) across %d file(s); %d load error(s).\n"
-        .. "Fix: hoist desc/silent/noremap/... out of the nested { ... } table\n"
-        .. "to the top level of the keymap entry (see LazyKeysSpec).\n",
+        .. "Fix (nested opts): hoist desc/silent/noremap/... out of the nested { ... }\n"
+        .. "table to the top level of the keymap entry (see LazyKeysSpec).\n"
+        .. "Fix (desc): give the mapping a non-empty desc so it is labelled in\n"
+        .. "which-key, :map and keymap pickers.\n",
       total_violations,
       #files,
       total_errors


### PR DESCRIPTION
## Problem

`lua/**/keys.lua` の 25 エントリで `desc` が空だった（24 件が `desc = ""`、1 件は `desc` 行自体が無い）。
desc が無いマッピングは which-key / `:map` / keymap picker で説明なしに並ぶため、後から意味が分からなくなる。

`task ck`（`scripts/check-keys-spec.lua`）は nested-opts バグしか見ておらず、この 25 件は素通りしていた。
プラグイン追加テンプレートが `desc = ""` を出力する以上、埋めるだけでは同じことがまた起きる。

## Solution

**1. 空 desc を 25 件埋める**

| ファイル | 件数 |
|---|---|
| `lua/plugins/crates-nvim/keys.lua` | 18 |
| `lua/plugins/cord-nvim/keys.lua` | 2 |
| `lua/plugins/vim-illuminate/keys.lua` | 2 |
| `lua/plugins/aerial-nvim/keys.lua` | 1 |
| `lua/plugins/yanky-nvim/keys.lua` | 1 |
| `lua/plugins/yankbank-nvim/keys.lua` | 1（`desc` 行を新規追加） |

crates の `<leader>cu` / `<leader>cU` は n / v で単数・複数が別関数なので、desc も分けてある。

lhs が `"<lhs>"` のままのテンプレート未記入エントリ（`denops-vim`、`wind-nvim`）は対象外。
プラグイン自体が未設定なので、desc だけ埋めても意味がない。

**2. `check-keys-spec.lua` に desc 検査を追加**

`desc` が nil なら `missing desc`、空文字なら `empty desc` として exit 1。
テンプレート placeholder のエントリはスキップするので、新規 vendor 直後に落ちることはない。

## Verification

- `task ck` → `OK: 56 keys.lua file(s) conform to LazyKeysSpec.`
- `stylua --check .` → clean / `selene scripts/check-keys-spec.lua` → 0 errors
- 全 keys.lua を `dofile` して走査し、空・欠落が 0 件であることを確認
- 検査が効くことを、わざと壊して確認した:
  desc を `""` に戻す → `empty desc` で exit 1、desc 行を消す → `missing desc` で exit 1、戻して exit 0

`selene .` 全体に出る 2 errors / 23 warnings は `lua/plugins/conform-nvim/formatters/`（ベンダリング済み・触らない領域）の既存分で、この PR とは無関係。