### PR TITLE
docs: relax the push rule to master only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,8 @@ master でも同じ結果になるので、**この症状を自分の変更の�
   worktree の中で使うときは `NVIM_PLUGINS_DIR` を明示する
 - テンプレートは `~/NVIM_PLUGIN_TEMPLATES`（**別リポジトリ**）。
   ここを直さないと、生成されるファイルに同じ間違いが増え続ける
-- **設定変更のコミットはユーザー自身が行う。** Claude は push しない
+- **Claude は master へ push しない。** feature ブランチへの commit / push は、
+  指示があれば行ってよい。PR のマージはユーザー自身が行う
 
 ### worktree で並行編集するとき
 


### PR DESCRIPTION
## Problem

`CLAUDE.md` の「このリポジトリの道具」節にあった1行:

> - **設定変更のコミットはユーザー自身が行う。** Claude は push しない

これは実態と合っていない。作業を投げるときに「push もやっておいて」で毎回上書きされており、
**実際には毎回許可している動作を禁止と書いている**状態だった。守られないルールは、
他の行の信頼度も下げる。

## Solution

守りたいのは「master が勝手に動かないこと」であって「commit しないこと」ではないので、
そこだけを残す形に書き換える。

> - **Claude は master へ push しない。** feature ブランチへの commit / push は、
>   指示があれば行ってよい。PR のマージはユーザー自身が行う

master への直接 push 禁止はグローバルの git ルール側にもあるため、この行は
「このリポジトリでも例外ではない」ことの再掲として機能する。

## Verification

1行の文書変更。`AGENTS.md` に同じ記述が無いことを確認済み（重複の取り残しなし）。