### PR TITLE
feat: add b0o/SchemaStore.nvim

### DIFF
--- a/lua/plugins/schemastore-nvim/ft.lua
+++ b/lua/plugins/schemastore-nvim/ft.lua
@@ -1,0 +1,9 @@
+---@type table
+local ft = {
+  "json",
+  "jsonc",
+  "json5",
+  "yaml",
+}
+
+return ft

--- a/lua/plugins/schemastore-nvim/init.lua
+++ b/lua/plugins/schemastore-nvim/init.lua
@@ -1,0 +1,10 @@
+---@type LazySpec
+local spec = {
+  "b0o/SchemaStore.nvim",
+  --lazy = false,
+  ft = require("plugins.schemastore-nvim.ft"),
+  --cond = false,
+  --enabled = false,
+}
+
+return spec


### PR DESCRIPTION
## 問題

json / yaml のスキーマ検証・補完に使う SchemaStore カタログを、この設定は持っていない。
`after/lsp/jsonls.lua` と `after/lsp/yamlls.lua` は空スタブのまま。

## 解決策

`b0o/SchemaStore.nvim` を vendoring し、lazy.nvim spec を追加する。

- `init.lua` — `ft = { json, jsonc, json5, yaml }` のみ。`setup()` を持たない
  カタログ提供ライブラリなので `opts` / `config` / `keys` / `cmd` は不要
- `dependencies` に `nvim-lspconfig` を入れていないのは、この設定が
  `after/lsp/*.lua`（`vim.lsp.config` 方式）を使っており lspconfig 本体に
  依存しないため
- 未使用の spec テンプレート（`cmds` / `events` / `keys` / `opts` /
  `dependencies`）は削除

## 検証

- `stylua --check lua/plugins/schemastore-nvim/*.lua` — pass
- headless で `Lazy! install` + `Lazy! load` 後、
  `#require("schemastore").json.schemas()` が 1418 件を返すことを確認

## 補足

このプラグイン単体では何も起きない。カタログを jsonls / yamlls の `settings` へ
渡す配線は別 PR で積む。