### PR TITLE
feat(lsp): wire SchemaStore catalog into jsonls and yamlls

### DIFF
--- a/after/lsp/jsonls.lua
+++ b/after/lsp/jsonls.lua
@@ -1,6 +1,11 @@
--- TODO: json ls configs
-
 ---@type vim.lsp.Config
-local config = {}
+local config = {
+  settings = {
+    json = {
+      schemas = require("schemastore").json.schemas(),
+      validate = { enable = true },
+    },
+  },
+}
 
 return config

--- a/after/lsp/yamlls.lua
+++ b/after/lsp/yamlls.lua
@@ -1,6 +1,16 @@
--- TODO: yaml ls configs
-
 ---@type vim.lsp.Config
-local config = {}
+local config = {
+  settings = {
+    yaml = {
+      -- NOTE: the built-in schema store must be disabled to use SchemaStore.nvim
+      schemaStore = {
+        enable = false,
+        -- NOTE: empty url avoids a TypeError in yaml-language-server
+        url = "",
+      },
+      schemas = require("schemastore").yaml.schemas(),
+    },
+  },
+}
 
 return config


### PR DESCRIPTION
## 問題

`after/lsp/jsonls.lua` と `after/lsp/yamlls.lua` は `-- TODO: ... ls configs` の
空スタブのままで、SchemaStore.nvim を入れてもカタログを渡す先が無く、
json / yaml のスキーマ検証も補完も効かない。

## 解決策

両サーバの `settings` にカタログを渡す。

- `jsonls` — `json.schemas` にカタログを渡し、`validate.enable = true` を設定
  （検証を有効にしないとスキーマが効かない。upstream b0o/SchemaStore.nvim#8）
- `yamlls` — `yaml.schemas` にカタログを渡し、内蔵スキーマストアを
  `schemaStore.enable = false` で無効化。二重に読ませると SchemaStore.nvim 側の
  `select` / `ignore` が効かなくなる。`url = ""` は
  yaml-language-server 側の TypeError 回避で、upstream README が明示している

## 検証

- `stylua --check after/lsp/jsonls.lua after/lsp/yamlls.lua` — pass
- headless で `vim.lsp.config` の解決結果を確認:
  `JSONLS=1418 VALIDATE=true YAMLLS=1325 STORE=false`
  （json バッファを開かずに解決できているので、`ft` で遅延した状態からでも
  lazy.nvim の require フック経由でロードされることも同時に確認できた）

## #287 との関係

#287 の切り直し。#286 のマージ時に GitHub が #287 の base を master へ付け替えて
rebase した結果、`lua/plugins/schemastore-nvim/CODES/` 一式を再追加するコミットが
紛れ込んでいた（master では意図的に削除済みのもの）。この PR は現在の master から
切り直し、`after/lsp` の変更のみを含む。#287 はクローズする。