### PR TITLE
feat: add windwp/nvim-ts-autotag

### DIFF
--- a/lua/plugins/nvim-ts-autotag/dependencies.lua
+++ b/lua/plugins/nvim-ts-autotag/dependencies.lua
@@ -1,0 +1,6 @@
+---@type LazySpec[]
+local dependencies = {
+  "nvim-treesitter/nvim-treesitter",
+}
+
+return dependencies

--- a/lua/plugins/nvim-ts-autotag/events.lua
+++ b/lua/plugins/nvim-ts-autotag/events.lua
@@ -1,0 +1,8 @@
+---@type table
+local events = {
+  --"VeryLazy",
+  "BufReadPre",
+  "BufNewFile",
+}
+
+return events

--- a/lua/plugins/nvim-ts-autotag/init.lua
+++ b/lua/plugins/nvim-ts-autotag/init.lua
@@ -1,0 +1,28 @@
+---@type LazySpec
+local spec = {
+  "windwp/nvim-ts-autotag",
+  --lazy = false,
+  event = require("plugins.nvim-ts-autotag.events"),
+  dependencies = require("plugins.nvim-ts-autotag.dependencies"),
+  --opts = require("plugins.nvim-ts-autotag.opts"),
+  config = function()
+    local opts = require("plugins.nvim-ts-autotag.opts")
+    require("nvim-ts-autotag").setup(opts)
+
+    -- Enable update on insert
+    -- If you have that issue: https://github.com/windwp/nvim-ts-autotag/issues/19
+
+    --vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {
+    --  underline = true,
+    --  virtual_text = {
+    --    spacing = 5,
+    --    severity_limit = "Warning",
+    --  },
+    --  update_in_insert = true,
+    --})
+  end,
+  --cond = false,
+  --enabled = false,
+}
+
+return spec

--- a/lua/plugins/nvim-ts-autotag/opts/aliases.lua
+++ b/lua/plugins/nvim-ts-autotag/opts/aliases.lua
@@ -1,0 +1,29 @@
+-- Aliases a filetype to an existing filetype tag config
+---@type { [string]: string }
+local aliases = {
+  ["astro"] = "html",
+  ["dot"] = "html",
+  ["eruby"] = "html",
+  ["liquid"] = "html",
+  ["vue"] = "html",
+  ["vento"] = "html",
+  ["htmlangular"] = "html",
+  ["htmldjango"] = "html",
+  ["markdown"] = "html",
+  ["php"] = "html",
+  ["twig"] = "html",
+  ["blade"] = "html",
+  ["elixir"] = "heex",
+  ["javascriptreact"] = "typescriptreact",
+  ["javascript.jsx"] = "typescriptreact",
+  ["typescript.tsx"] = "typescriptreact",
+  ["javascript"] = "typescriptreact",
+  ["typescript"] = "typescriptreact",
+  ["rescript"] = "typescriptreact",
+  ["handlebars"] = "glimmer",
+  ["javascript.glimmer"] = "typescript.glimmer",
+  ["hbs"] = "glimmer",
+  ["rust"] = "rust",
+}
+
+return aliases

--- a/lua/plugins/nvim-ts-autotag/opts/init.lua
+++ b/lua/plugins/nvim-ts-autotag/opts/init.lua
@@ -1,0 +1,16 @@
+---@type nvim-ts-autotag.PluginSetup
+local opts = {
+  -- General setup options
+  ---@type nvim-ts-autotag.Opts
+  opts = require("plugins.nvim-ts-autotag.opts.options"),
+
+  -- Aliases a filetype to an existing filetype tag config
+  ---@type { [string]: string }
+  aliases = require("plugins.nvim-ts-autotag.opts.aliases"),
+
+  -- Per filetype config overrides
+  ---@type { [string]: nvim-ts-autotag.Opts }
+  per_filetype = require("plugins.nvim-ts-autotag.opts.per_filetype"),
+}
+
+return opts

--- a/lua/plugins/nvim-ts-autotag/opts/options.lua
+++ b/lua/plugins/nvim-ts-autotag/opts/options.lua
@@ -1,0 +1,17 @@
+-- General setup options
+---@type nvim-ts-autotag.Opts
+local options = {
+  -- Whether or not to auto rename paired tags
+  ---@type boolean
+  enable_rename = true,
+
+  -- Whether or not to auto close tags
+  ---@type boolean
+  enable_close = true,
+
+  -- Whether or not to auto close tags when a `/` is inserted
+  ---@type boolean
+  enable_close_on_slash = false,
+}
+
+return options

--- a/lua/plugins/nvim-ts-autotag/opts/per_filetype.lua
+++ b/lua/plugins/nvim-ts-autotag/opts/per_filetype.lua
@@ -1,0 +1,9 @@
+-- Per filetype config overrides
+---@type { [string]: nvim-ts-autotag.Opts }
+local per_filetype = {
+  ["html"] = {
+    enable_close = false,
+  },
+}
+
+return per_filetype


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic HTML and JSX-style tag management in the editor.
  * Tags can now be renamed together and automatically closed while typing.
  * Added support for multiple markup-related file types, including React, HEEx, Glimmer, and Rust.
  * Customized behavior for HTML files by disabling automatic tag closing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->