### PR TITLE
feat: add chrisgrieser/nvim-lsp-endhints

### DIFF
--- a/lua/plugins/nvim-lsp-endhints/events.lua
+++ b/lua/plugins/nvim-lsp-endhints/events.lua
@@ -1,0 +1,7 @@
+---@type table
+local events = {
+  --"VeryLazy",
+  "LspAttach",
+}
+
+return events

--- a/lua/plugins/nvim-lsp-endhints/init.lua
+++ b/lua/plugins/nvim-lsp-endhints/init.lua
@@ -1,0 +1,15 @@
+---@type LazySpec
+local spec = {
+  "chrisgrieser/nvim-lsp-endhints",
+  --lazy = false,
+  event = require("plugins.nvim-lsp-endhints.events"),
+  --opts = require("plugins.nvim-lsp-endhints.opts"),
+  config = function()
+    local opts = require("plugins.nvim-lsp-endhints.opts")
+    require("lsp-endhints").setup(opts)
+  end,
+  cond = false,
+  enabled = false,
+}
+
+return spec

--- a/lua/plugins/nvim-lsp-endhints/opts.lua
+++ b/lua/plugins/nvim-lsp-endhints/opts.lua
@@ -1,0 +1,33 @@
+---@type LspEndhints.config
+local opts = {
+  autoEnableHints = true,
+
+  icons = {
+    type = "󰜁 ",
+    parameter = "󰏪 ",
+    -- hint kind not defined in official LSP spec
+    offspec = " ",
+
+    -- hint kind is nil
+    unknown = " ",
+  },
+
+  label = {
+    truncateAtChars = 20,
+    padding = 1,
+    marginLeft = 0,
+    sameKindSeparator = ", ",
+  },
+
+  extmark = {
+    priority = 50,
+  },
+
+  -- Function that overrides how hints are displayed.
+  -- expects as output a table for `virt_text` from `nvim_buf_set_extmark`, that is a table of string tuples (text & highlight group)
+  -- To use filetype-specific formatting, get the filetype via `vim.bo[bufnr].filetype`, to conditionally use the default formatting function, use `defaultHintFormatFunc(hints)`.
+  ---@type function (hints: {label: string, col: number, kind: string}[], bufnr: number, defaultHintFormatFunc: func): {[1]: string, [2]: string}[]
+  hintFormatFunc = nil,
+}
+
+return opts


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying inline LSP parameter hints in the editor.
  * Hints activate automatically when an LSP attaches.
  * Added configurable hint icons, formatting, display priority, and custom formatting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->