### PR TITLE
feat: add n3tw0rth/keeper.nvim

### DIFF
--- a/lua/plugins/keeper-nvim/cmds.lua
+++ b/lua/plugins/keeper-nvim/cmds.lua
@@ -1,0 +1,6 @@
+---@type table
+local cmds = {
+  "Keeper",
+}
+
+return cmds

--- a/lua/plugins/keeper-nvim/events.lua
+++ b/lua/plugins/keeper-nvim/events.lua
@@ -1,0 +1,6 @@
+---@type table
+local events = {
+  "VeryLazy",
+}
+
+return events

--- a/lua/plugins/keeper-nvim/init.lua
+++ b/lua/plugins/keeper-nvim/init.lua
@@ -1,0 +1,17 @@
+---@type LazySpec
+local spec = {
+  "n3tw0rth/keeper.nvim",
+  --lazy = false,
+  cmd = require("plugins.keeper-nvim.cmds"),
+  keys = require("plugins.keeper-nvim.keys"),
+  event = require("plugins.keeper-nvim.events"),
+  --opts = require("plugins.keeper-nvim.opts"),
+  config = function()
+    local opts = require("plugins.keeper-nvim.opts")
+    require("keeper").setup(opts)
+  end,
+  --cond = false,
+  --enabled = false,
+}
+
+return spec

--- a/lua/plugins/keeper-nvim/keys.lua
+++ b/lua/plugins/keeper-nvim/keys.lua
@@ -1,0 +1,16 @@
+---@type LazyKeysSpec[]
+local keys = {
+  {
+    "_",
+    function()
+      require("keeper.view").view_buffer()
+    end,
+    mode = {
+      "n",
+    },
+    desc = "Open the keeper buffer list",
+    silent = true,
+  },
+}
+
+return keys

--- a/lua/plugins/keeper-nvim/opts.lua
+++ b/lua/plugins/keeper-nvim/opts.lua
@@ -1,0 +1,19 @@
+---@type KeeperConfig
+local opts = {
+  -- register the :Keeper command
+  ---@type boolean
+  enabled = true,
+
+  ---@type KeeperSaveNRestoreConfig
+  save_n_restore = {
+    -- save the buffer list on exit and restore it on start
+    ---@type boolean
+    enabled = true,
+
+    -- path of the JSON file buffer lists are saved to
+    ---@type string
+    save_file = vim.fn.stdpath("data") .. "/keeper/buffers.json",
+  },
+}
+
+return opts


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Keeper integration for managing and viewing saved buffers in Neovim.
  * Added the `Keeper` command and a normal-mode shortcut (`_`) to open the buffer list.
  * Enabled automatic loading when Neovim becomes idle.
  * Added configurable buffer save and restore behavior, with persistence under Neovim’s data directory.
  * Keeper settings are now loaded automatically during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->