### PR TITLE
feat: add rachartier/tiny-code-action.nvim

### DIFF
--- a/lua/plugins/tiny-code-action-nvim/dependencies.lua
+++ b/lua/plugins/tiny-code-action-nvim/dependencies.lua
@@ -1,0 +1,8 @@
+---@type LazySpec[]
+local dependencies = {
+  --"nvim-telescope/telescope.nvim",
+  --"ibhagwan/fzf-lua",
+  "folke/snacks.nvim",
+}
+
+return dependencies

--- a/lua/plugins/tiny-code-action-nvim/events.lua
+++ b/lua/plugins/tiny-code-action-nvim/events.lua
@@ -1,0 +1,7 @@
+---@type table
+local events = {
+  "LspAttach",
+  --"VeryLazy",
+}
+
+return events

--- a/lua/plugins/tiny-code-action-nvim/init.lua
+++ b/lua/plugins/tiny-code-action-nvim/init.lua
@@ -1,0 +1,17 @@
+---@type LazySpec
+local spec = {
+  "rachartier/tiny-code-action.nvim",
+  --lazy = false,
+  keys = require("plugins.tiny-code-action-nvim.keys"),
+  event = require("plugins.tiny-code-action-nvim.events"),
+  dependencies = require("plugins.tiny-code-action-nvim.dependencies"),
+  --opts = require("plugins.tiny-code-action-nvim.opts"),
+  config = function()
+    local opts = require("plugins.tiny-code-action-nvim.opts")
+    require("tiny-code-action").setup(opts)
+  end,
+  --cond = false,
+  --enabled = false,
+}
+
+return spec

--- a/lua/plugins/tiny-code-action-nvim/keys.lua
+++ b/lua/plugins/tiny-code-action-nvim/keys.lua
@@ -1,0 +1,18 @@
+---@type LazyKeysSpec[]
+local keys = {
+  {
+    "<leader>ca",
+    function()
+      require("tiny-code-action").code_action()
+    end,
+    mode = {
+      "n",
+      "x",
+    },
+    desc = "tiny-code-action",
+    noremap = true,
+    silent = true,
+  },
+}
+
+return keys

--- a/lua/plugins/tiny-code-action-nvim/opts/backend_opts.lua
+++ b/lua/plugins/tiny-code-action-nvim/opts/backend_opts.lua
@@ -1,0 +1,31 @@
+local backend_opts = {
+  delta = {
+    -- Header from delta can be quite large.
+    -- You can remove them by setting this to the number of lines to remove
+    header_lines_to_remove = 4,
+
+    -- The arguments to pass to delta
+    args = {
+      "--line-numbers",
+      -- If you have a custom configuration file, you can set the path to it like so:
+      --"--config" .. os.getenv("HOME") .. "/.config/delta/config.yml",
+    },
+  },
+
+  difftastic = {
+    header_lines_to_remove = 1,
+
+    -- The arguments to pass to difftastic
+    args = {
+      "--color=always",
+      "--display=inline",
+      "--syntax-highlight=on",
+    },
+  },
+
+  diffsofancy = {
+    header_lines_to_remove = 4,
+  },
+}
+
+return backend_opts

--- a/lua/plugins/tiny-code-action-nvim/opts/init.lua
+++ b/lua/plugins/tiny-code-action-nvim/opts/init.lua
@@ -1,0 +1,81 @@
+---@type table
+local opts = {
+  ---@type string | "vim" | "delta" | "difftastic" | "diffsofancy"
+  backend = "vim",
+
+  ---@type string | "telescope" | "snacks" | "select" | "buffer" | "fzf-lua" | table | nil
+  picker = require("plugins.tiny-code-action-nvim.opts.picker"),
+
+  -- Customize how action titles are displayed in the picker
+  -- Function receives (action, client) and returns a formatted string
+  -- action.title: The action's title text
+  -- action.kind: The LSP CodeActionKind (e.g., "quickfix", "refactor.extract")
+  -- action.isPreferred: Boolean indicating if the action is preferred
+  -- client.name: The name of the LSP client providing the action
+  format_title = function(action, client)
+    if action.kind then
+      return string.format("%s (%s)", action.title, action.kind)
+    end
+    return action.title
+  end,
+
+  backend_opts = require("plugins.tiny-code-action-nvim.opts.backend_opts"),
+
+  -- Timeout in milliseconds to resolve code actions
+  resolve_timeout = 100,
+
+  sort = function(a, b)
+    -- Global Configuration
+    --[[
+    -- Prioritize actions from rust_analyzer
+    if a.client.name == "rust_analyzer" and b.client.name ~= "rust_analyzer" then
+      return true
+    elseif a.client.name ~= "rust_analyzer" and b.client.name == "rust_analyzer" then
+      return false
+    end
+
+    -- Sort by action kind alphabetically
+    local a_kind = a.action.kind or ""
+    local b_kind = b.action.kind or ""
+    return a_kind < b_kind
+    ]]
+
+    -- Per-Call Sorting
+    --[[
+    -- Prioritize "Disable" actions
+    local a_is_disable = string.match(a.action.title, "Disable") ~= nil
+    local b_is_disable = string.match(b.action.title, "Disable") ~= nil
+
+    if a_is_disable and not b_is_disable then
+      return true
+    elseif not a_is_disable and b_is_disable then
+      return false
+    end
+
+    return false
+    ]]
+    -- Prioritize quickfix actions, then refactoring, then everything else
+    --[[
+    local function get_priority(kind)
+      if string.match(kind or "", "^quickfix") then return 1 end
+      if string.match(kind or "", "^refactor") then return 2 end
+      return 3
+    end
+
+    local a_priority = get_priority(a.action.kind)
+    local b_priority = get_priority(b.action.kind)
+
+    return a_priority < b_priority
+    ]]
+  end,
+
+  -- Notification settings
+  notify = require("plugins.tiny-code-action-nvim.opts.notify"),
+
+  -- The icons to use for the code actions
+  -- You can add your own icons, you just need to set the exact action's kind of the code action
+  -- You can set the highlight like so: { link = "DiagnosticError" } or  like nvim_set_hl ({ fg ..., bg..., bold..., ...})
+  signs = require("plugins.tiny-code-action-nvim.opts.signs"),
+}
+
+return opts

--- a/lua/plugins/tiny-code-action-nvim/opts/notify.lua
+++ b/lua/plugins/tiny-code-action-nvim/opts/notify.lua
@@ -1,0 +1,10 @@
+-- Notification settings
+local notify = {
+  -- Enable/disable all notifications
+  enabled = true,
+
+  -- Show notification when no code actions are found
+  on_empty = true,
+}
+
+return notify

--- a/lua/plugins/tiny-code-action-nvim/opts/picker.lua
+++ b/lua/plugins/tiny-code-action-nvim/opts/picker.lua
@@ -1,0 +1,115 @@
+local picker_buffer = {
+  "buffer",
+  opts = {
+    -- Enable/Disable hotkeys for quick selection of actions
+    hotkeys = false,
+
+    -- Modes for generating hotkeys
+    -- can also be a function(titles, used_hotkeys) returning a list of hotkey strings
+    ---@type string | "sequential" | "text_based" | "text_diff_based" | function(titles, used_hotkeys)
+    hotkeys_mode = function(_titles, _used_hotkeys)
+      --local t = {}
+      --for i = 1, #titles do
+      --  t[i] = tostring(i)
+      --end
+      --return t
+      return "text_diff_based"
+    end,
+
+    -- Enable or disable automatic preview
+    auto_preview = false,
+
+    -- Automatically accept the selected action (with hotkeys)
+    auto_accept = false,
+
+    -- Position of the picker window
+    position = "cursor",
+
+    -- Border style for picker and preview windows
+    ---@type string | "single" | nil
+    winborder = nil,
+
+    conceallevel = 1,
+
+    keymaps = {
+      -- Key to show preview
+      preview = "K",
+
+      -- Keys to close the window (can be string or table)
+      close = {
+        "q",
+        "<Esc>",
+      },
+
+      -- Keys to select action (can be string or table)
+      select = "<CR>",
+
+      back = "<Backspace>",
+
+      -- Keys to return from preview to main window (can be string or table)
+      preview_close = {
+        "q",
+        "<Esc>",
+      },
+    },
+
+    custom_keys = {
+      {
+        key = "m",
+        pattern = "Fill match arms",
+      },
+
+      {
+        key = "m",
+        pattern = "Consider making this binding mutable: mut",
+      },
+
+      -- Lua pattern matching
+      {
+        key = "r",
+        pattern = "Rename.*",
+      },
+
+      {
+        key = "e",
+        pattern = "Extract Method",
+      },
+    },
+
+    ---@type string | "▶ " | " └",
+    group_icon = "▶ ",
+  },
+}
+
+local picker_telescope = {
+  "telescope",
+  opts = {
+    layout_strategy = "vertical",
+    layout_config = {
+      width = 0.7,
+      height = 0.9,
+      preview_cutoff = 1,
+      preview_height = function(_, _, max_lines)
+        local h = math.floor(max_lines * 0.5)
+        return math.max(h, 10)
+      end,
+    },
+  },
+}
+
+local picker_snacks = {
+  "snacks",
+  opts = {
+    layout = "vertical",
+  },
+}
+
+local picker_select = {
+  "select",
+  opts = {},
+}
+
+---@type string | "telescope" | "snacks" | "select" | "buffer" | "fzf-lua" | table | nil
+local picker = picker_snacks
+
+return picker

--- a/lua/plugins/tiny-code-action-nvim/opts/signs.lua
+++ b/lua/plugins/tiny-code-action-nvim/opts/signs.lua
@@ -1,0 +1,76 @@
+-- The icons to use for the code actions
+-- You can add your own icons, you just need to set the exact action's kind of the code action
+-- You can set the highlight like so: { link = "DiagnosticError" } or  like nvim_set_hl ({ fg ..., bg..., bold..., ...})
+local signs = {
+  quickfix = {
+    "",
+    {
+      link = "DiagnosticWarning",
+    },
+  },
+
+  others = {
+    "",
+    {
+      link = "DiagnosticWarning",
+    },
+  },
+
+  refactor = {
+    "",
+    {
+      link = "DiagnosticInfo",
+    },
+  },
+
+  ["refactor.move"] = {
+    "󰪹",
+    {
+      link = "DiagnosticInfo",
+    },
+  },
+
+  ["refactor.extract"] = {
+    "",
+    {
+      link = "DiagnosticError",
+    },
+  },
+
+  ["source.organizeImports"] = {
+    "",
+    {
+      link = "DiagnosticWarning",
+    },
+  },
+
+  ["source.fixAll"] = {
+    "󰃢",
+    {
+      link = "DiagnosticError",
+    },
+  },
+
+  ["source"] = {
+    "",
+    {
+      link = "DiagnosticError",
+    },
+  },
+
+  ["rename"] = {
+    "󰑕",
+    {
+      link = "DiagnosticWarning",
+    },
+  },
+
+  ["codeAction"] = {
+    "",
+    {
+      link = "DiagnosticWarning",
+    },
+  },
+}
+
+return signs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tiny Code Action support for browsing and applying LSP code actions.
  * Added the `<leader>ca` shortcut for invoking code actions in normal and visual modes.
  * Added a Snacks-based picker with vertical layout, navigation shortcuts, previews, and action matching.
  * Added descriptive action titles, notifications, configurable signs, and support for multiple diff backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->