### PR TITLE
feat(tsstatus): add :TSStatus, a one-screen view of parser state

### DIFF
--- a/lua/config/usercmds.lua
+++ b/lua/config/usercmds.lua
@@ -204,3 +204,12 @@ end, {
     return plugin_names(collect(vim.api.nvim_get_current_buf()), lead)
   end,
 })
+
+-- :TSStatus -- nvim-treesitter installs parsers asynchronously and reports the
+-- result only through :TSLog, so "did all of them finish?" has no answer while
+-- the session is running. lua/tsstatus renders that answer as a screen.
+vim.api.nvim_create_user_command("TSStatus", function()
+  require("tsstatus").open()
+end, {
+  desc = "Show tree-sitter parser install status (installed / outdated / missing)",
+})

--- a/lua/plugins/nvim-treesitter/init.lua
+++ b/lua/plugins/nvim-treesitter/init.lua
@@ -5,6 +5,10 @@ local spec = {
   build = ":TSUpdate",
   cmd = require("plugins.nvim-treesitter.cmds"),
   config = function()
+    -- Hook the installer's logger before the first install starts, so :TSStatus
+    -- can show what each parser is doing during the startup run too.
+    require("tsstatus").setup()
+
     local opts = require("plugins.nvim-treesitter.opts")
     local install_languages = require("plugins.nvim-treesitter.install.languages")
     local install_options = require("plugins.nvim-treesitter.install.options")

--- a/lua/tsstatus/actions.lua
+++ b/lua/tsstatus/actions.lua
@@ -1,0 +1,66 @@
+-- The three things the screen can do to a parser, on top of nvim-treesitter's
+-- public API. Nothing here waits for completion: the tracker turns the
+-- installer's log into live rows, so the window is the progress report.
+
+local M = {}
+
+---@return table? nvim_treesitter
+local function api()
+  local ok, ts = pcall(require, "nvim-treesitter")
+  if not ok then
+    vim.notify("TSStatus: nvim-treesitter is not available", vim.log.levels.ERROR)
+    return nil
+  end
+  return ts
+end
+
+---@param what string
+---@param task any
+local function report(what, task)
+  if type(task) ~= "table" or type(task.await) ~= "function" then
+    return
+  end
+  task:await(vim.schedule_wrap(function(err)
+    if err then
+      vim.notify(("TSStatus: %s failed: %s"):format(what, tostring(err)), vim.log.levels.ERROR)
+    end
+  end))
+end
+
+---@param langs string[]
+---@param force boolean? reinstall parsers that are already present
+function M.install(langs, force)
+  local ts = api()
+  if not ts or #langs == 0 then
+    return
+  end
+  -- summary = false: the screen already shows per-parser state, and the
+  -- summary line only adds a hit-enter prompt on top of it.
+  report("install", ts.install(langs, { force = force, summary = false }))
+end
+
+---@param langs string[]
+function M.update(langs)
+  local ts = api()
+  if not ts or #langs == 0 then
+    return
+  end
+  report("update", ts.update(langs, { summary = false }))
+end
+
+---@param langs string[]
+function M.uninstall(langs)
+  local ts = api()
+  if not ts or #langs == 0 then
+    return
+  end
+  -- Uninstall deletes files, so it is the one action that asks first.
+  local subject = #langs == 1 and langs[1] or ("%d parsers"):format(#langs)
+  local answer = vim.fn.confirm(("Uninstall %s?"):format(subject), "&Yes\n&No", 2)
+  if answer ~= 1 then
+    return
+  end
+  report("uninstall", ts.uninstall(langs, { summary = false }))
+end
+
+return M

--- a/lua/tsstatus/data.lua
+++ b/lua/tsstatus/data.lua
@@ -1,0 +1,148 @@
+-- Status of every tree-sitter parser nvim-treesitter knows about.
+--
+-- Pure computation: reads the parser registry and the install directory, never
+-- installs, never touches the UI. Everything here comes from three public
+-- entry points (config.get_available, config.get_installed, the parsers table)
+-- plus the `<install_dir>/parser-info/<lang>.revision` files nvim-treesitter
+-- writes after a successful install. That is the whole dependency surface, so
+-- this module can be lifted out of this config unchanged.
+
+local M = {}
+
+---@alias TSStatusState
+---| "installed"    parser present and at the revision the registry asks for
+---| "outdated"     parser present, revision differs (or was never recorded)
+---| "missing"      registry has a grammar for it, nothing is installed
+---| "queries_only" no grammar of its own; it only ships queries other langs use
+---| "orphan"       a parser is installed that the registry no longer lists
+
+---@class TSStatusEntry
+---@field lang string
+---@field state TSStatusState
+---@field tier integer?
+---@field wanted string? revision the registry asks for
+---@field have string? revision recorded at install time
+---@field queries boolean queries directory is present
+
+---@class TSStatusReport
+---@field entries TSStatusEntry[]
+---@field counts table<TSStatusState, integer>
+---@field install_dir string
+
+-- Unsupported parsers (tier 4) are never installed by `install("all")`, so
+-- counting them as missing would keep the screen permanently red.
+local TIER_UNSUPPORTED = 4
+
+---@param dir string
+---@param lang string
+---@return string?
+local function read_revision(dir, lang)
+  local file = vim.fs.joinpath(dir, lang .. ".revision")
+  local fd = io.open(file, "r")
+  if not fd then
+    return nil
+  end
+  local content = fd:read("*a")
+  fd:close()
+  return vim.trim(content or "")
+end
+
+---@param list string[]
+---@return table<string, boolean>
+local function to_set(list)
+  local set = {}
+  for _, item in ipairs(list) do
+    set[item] = true
+  end
+  return set
+end
+
+---@return TSStatusReport
+function M.collect()
+  local config = require("nvim-treesitter.config")
+  local parsers = require("nvim-treesitter.parsers")
+
+  local info_dir = config.get_install_dir("parser-info")
+  local installed = to_set(config.get_installed("parsers"))
+  local queries = to_set(config.get_installed("queries"))
+
+  local entries = {}
+  local counts = {
+    installed = 0,
+    outdated = 0,
+    missing = 0,
+    queries_only = 0,
+    orphan = 0,
+  }
+
+  ---@param entry TSStatusEntry
+  local function push(entry)
+    entries[#entries + 1] = entry
+    counts[entry.state] = counts[entry.state] + 1
+  end
+
+  for _, lang in ipairs(config.get_available()) do
+    local parser = parsers[lang] or {}
+    local install_info = parser.install_info
+
+    -- tier 4 is never part of an "all" install, so listing it would leave a
+    -- permanent "missing" on screen.
+    if parser.tier ~= TIER_UNSUPPORTED then
+      if not install_info then
+        -- ecma, jsx, html_tags, ... exist only to ship queries for other
+        -- languages. They have no parser to install, so looking for a .so here
+        -- would report a permanent, meaningless "missing".
+        push({
+          lang = lang,
+          state = "queries_only",
+          tier = parser.tier,
+          queries = queries[lang] == true,
+        })
+      elseif not installed[lang] then
+        push({
+          lang = lang,
+          state = "missing",
+          tier = parser.tier,
+          wanted = install_info.revision,
+          queries = queries[lang] == true,
+        })
+      else
+        local wanted = install_info.revision
+        local have = read_revision(info_dir, lang)
+        -- No pinned revision means the parser tracks a branch; there is nothing
+        -- to compare against, so treat it as current rather than guessing.
+        local stale = wanted ~= nil and wanted ~= have
+        push({
+          lang = lang,
+          state = stale and "outdated" or "installed",
+          tier = parser.tier,
+          wanted = wanted,
+          have = have,
+          queries = queries[lang] == true,
+        })
+      end
+    end
+  end
+
+  for lang in pairs(installed) do
+    if parsers[lang] == nil then
+      push({
+        lang = lang,
+        state = "orphan",
+        queries = queries[lang] == true,
+      })
+    end
+  end
+
+  table.sort(entries, function(a, b)
+    return a.lang < b.lang
+  end)
+
+  return {
+    entries = entries,
+    counts = counts,
+    install_dir = vim.fs.dirname(info_dir),
+  }
+end
+
+return M

--- a/lua/tsstatus/data.lua
+++ b/lua/tsstatus/data.lua
@@ -10,6 +10,8 @@
 local M = {}
 
 ---@alias TSStatusState
+---| "installing"   an install is running for it right now
+---| "failed"       the last install attempt logged an error
 ---| "installed"    parser present and at the revision the registry asks for
 ---| "outdated"     parser present, revision differs (or was never recorded)
 ---| "missing"      registry has a grammar for it, nothing is installed
@@ -23,6 +25,8 @@ local M = {}
 ---@field wanted string? revision the registry asks for
 ---@field have string? revision recorded at install time
 ---@field queries boolean queries directory is present
+---@field phase string? live phase, when an install is in flight
+---@field message string? last message from the installer
 
 ---@class TSStatusReport
 ---@field entries TSStatusEntry[]
@@ -57,8 +61,10 @@ local function to_set(list)
   return set
 end
 
+---@param progress table<string, TSTrackEntry>? live state from tsstatus.track
 ---@return TSStatusReport
-function M.collect()
+function M.collect(progress)
+  progress = progress or {}
   local config = require("nvim-treesitter.config")
   local parsers = require("nvim-treesitter.parsers")
 
@@ -68,6 +74,8 @@ function M.collect()
 
   local entries = {}
   local counts = {
+    installing = 0,
+    failed = 0,
     installed = 0,
     outdated = 0,
     missing = 0,
@@ -77,6 +85,14 @@ function M.collect()
 
   ---@param entry TSStatusEntry
   local function push(entry)
+    -- What the installer is doing right now outranks what the disk shows: a
+    -- parser being compiled is neither missing nor installed yet.
+    local live = progress[entry.lang]
+    if live then
+      entry.state = live.phase == "failed" and "failed" or "installing"
+      entry.phase = live.phase
+      entry.message = live.message
+    end
     entries[#entries + 1] = entry
     counts[entry.state] = counts[entry.state] + 1
   end

--- a/lua/tsstatus/data.lua
+++ b/lua/tsstatus/data.lua
@@ -25,6 +25,7 @@ local M = {}
 ---@field wanted string? revision the registry asks for
 ---@field have string? revision recorded at install time
 ---@field queries boolean queries directory is present
+---@field queries_missing boolean? parser is installed but its queries are not
 ---@field phase string? live phase, when an install is in flight
 ---@field message string? last message from the installer
 
@@ -128,13 +129,18 @@ function M.collect(progress)
         -- No pinned revision means the parser tracks a branch; there is nothing
         -- to compare against, so treat it as current rather than guessing.
         local stale = wanted ~= nil and wanted ~= have
+        -- Highlighting comes from the queries, not the parser, so a parser
+        -- whose queries never landed is broken no matter what its revision
+        -- says. It needs a forced reinstall, which is what "outdated" routes to.
+        local no_queries = queries[lang] ~= true
         push({
           lang = lang,
-          state = stale and "outdated" or "installed",
+          state = (stale or no_queries) and "outdated" or "installed",
           tier = parser.tier,
           wanted = wanted,
           have = have,
-          queries = queries[lang] == true,
+          queries = not no_queries,
+          queries_missing = no_queries or nil,
         })
       end
     end

--- a/lua/tsstatus/init.lua
+++ b/lua/tsstatus/init.lua
@@ -1,0 +1,19 @@
+-- :TSStatus - one screen answering "is every tree-sitter parser installed and
+-- current?", which nvim-treesitter itself only answers through its log.
+--
+-- Deliberately read-only, and deliberately free of any dependency on the rest
+-- of this config: it talks to nvim-treesitter through its public API only, so
+-- moving this directory into a standalone plugin is a copy, not a rewrite.
+
+local M = {}
+
+function M.open()
+  require("tsstatus.ui").open()
+end
+
+---@return TSStatusReport
+function M.report()
+  return require("tsstatus.data").collect()
+end
+
+return M

--- a/lua/tsstatus/init.lua
+++ b/lua/tsstatus/init.lua
@@ -7,6 +7,13 @@
 
 local M = {}
 
+---Install the progress hooks. Call it as early as possible -- before the first
+---install starts -- if the live view should cover the startup run too.
+---@return boolean ok
+function M.setup()
+  return require("tsstatus.track").setup()
+end
+
 function M.open()
   require("tsstatus.ui").open()
 end

--- a/lua/tsstatus/track.lua
+++ b/lua/tsstatus/track.lua
@@ -14,7 +14,7 @@
 
 local M = {}
 
----@alias TSTrackPhase "queued"|"downloading"|"generating"|"compiling"|"installing"|"failed"
+---@alias TSTrackPhase "queued"|"downloading"|"generating"|"compiling"|"installing"|"uninstalling"|"failed"
 
 ---@class TSTrackEntry
 ---@field phase TSTrackPhase
@@ -50,12 +50,16 @@ local function changed()
 end
 
 ---@param ctx string?
----@return string? lang
+---@return string? lang, string? kind "install" or "uninstall"
 local function lang_of(ctx)
   if type(ctx) ~= "string" then
     return nil
   end
-  return ctx:match("^install/(.+)$") or ctx:match("^uninstall/(.+)$")
+  local lang = ctx:match("^install/(.+)$")
+  if lang then
+    return lang, "install"
+  end
+  return ctx:match("^uninstall/(.+)$"), "uninstall"
 end
 
 ---@param lang string
@@ -86,11 +90,11 @@ function M.setup()
 
   local new = log.new
   log.new = function(ctx)
-    local lang = lang_of(ctx)
+    local lang, kind = lang_of(ctx)
     if lang then
       -- The logger is created at the top of try_install_lang, so this is the
       -- moment the language leaves the queue.
-      set(lang, "queued")
+      set(lang, kind == "uninstall" and "uninstalling" or "queued")
     end
     return new(ctx)
   end
@@ -101,14 +105,15 @@ function M.setup()
 
   local info = logger.info
   logger.info = function(self, message, ...)
-    local lang = lang_of(self.ctx)
+    local lang, kind = lang_of(self.ctx)
     if lang then
       local text = select("#", ...) > 0 and message:format(...) or message
       if DONE[text] then
         state[lang] = nil
         changed()
       else
-        set(lang, PHASES[text:match("^%a+")] or "installing", text)
+        local fallback = kind == "uninstall" and "uninstalling" or "installing"
+        set(lang, PHASES[text:match("^%a+")] or fallback, text)
       end
     end
     return info(self, message, ...)
@@ -141,22 +146,6 @@ function M.busy()
     end
   end
   return false
-end
-
----Drop tracking for languages that reached a healthy state on disk, so a
----failure from an earlier run stops being reported once it is fixed.
----@param healthy table<string, boolean>
-function M.settle(healthy)
-  local dropped = false
-  for lang, entry in pairs(state) do
-    if healthy[lang] and entry.phase == "failed" then
-      state[lang] = nil
-      dropped = true
-    end
-  end
-  if dropped then
-    changed()
-  end
 end
 
 ---@param fn function

--- a/lua/tsstatus/track.lua
+++ b/lua/tsstatus/track.lua
@@ -1,0 +1,176 @@
+-- Live per-parser progress, recovered from nvim-treesitter's logger.
+--
+-- The installer exposes no progress callback: install() returns a single task
+-- for the whole batch, and everything that happens per language goes to
+-- nvim-treesitter.log instead. But it goes there with the language in the
+-- logger's context (`log.new("install/" .. lang)`) and with phase messages
+-- ("Downloading ...", "Compiling parser", "Language installed"), which is
+-- enough to reconstruct the state of every parser as it moves.
+--
+-- So this wraps two functions: log.new (a language started) and the Logger
+-- methods that carry the phase. Wrapping is confined to this file, and the
+-- screen still works without it -- the filesystem view in data.lua stands on
+-- its own, this only adds the moving parts.
+
+local M = {}
+
+---@alias TSTrackPhase "queued"|"downloading"|"generating"|"compiling"|"installing"|"failed"
+
+---@class TSTrackEntry
+---@field phase TSTrackPhase
+---@field message string?
+---@field started integer uv.now() at the first event for this language
+
+---@type table<string, TSTrackEntry>
+local state = {}
+
+---@type table<integer, function>
+local subscribers = {}
+local next_subscriber = 1
+
+local hooked = false
+
+-- Message prefixes the installer logs through the per-language logger.
+local PHASES = {
+  ["Downloading"] = "downloading",
+  ["Generating"] = "generating",
+  ["Compiling"] = "compiling",
+  ["Installing"] = "installing",
+}
+
+local DONE = {
+  ["Language installed"] = true,
+  ["Language uninstalled"] = true,
+}
+
+local function changed()
+  for _, fn in pairs(subscribers) do
+    pcall(fn)
+  end
+end
+
+---@param ctx string?
+---@return string? lang
+local function lang_of(ctx)
+  if type(ctx) ~= "string" then
+    return nil
+  end
+  return ctx:match("^install/(.+)$") or ctx:match("^uninstall/(.+)$")
+end
+
+---@param lang string
+---@param phase TSTrackPhase
+---@param message string?
+local function set(lang, phase, message)
+  local previous = state[lang]
+  state[lang] = {
+    phase = phase,
+    message = message,
+    started = previous and previous.started or vim.uv.now(),
+  }
+  changed()
+end
+
+---Install the hooks. Idempotent, and safe to call before nvim-treesitter has
+---been configured.
+---@return boolean ok
+function M.setup()
+  if hooked then
+    return true
+  end
+
+  local ok, log = pcall(require, "nvim-treesitter.log")
+  if not ok then
+    return false
+  end
+
+  local new = log.new
+  log.new = function(ctx)
+    local lang = lang_of(ctx)
+    if lang then
+      -- The logger is created at the top of try_install_lang, so this is the
+      -- moment the language leaves the queue.
+      set(lang, "queued")
+    end
+    return new(ctx)
+  end
+
+  -- Every logger instance resolves its methods through this one table, so
+  -- replacing them here covers loggers created before and after setup().
+  local logger = log.Logger
+
+  local info = logger.info
+  logger.info = function(self, message, ...)
+    local lang = lang_of(self.ctx)
+    if lang then
+      local text = select("#", ...) > 0 and message:format(...) or message
+      if DONE[text] then
+        state[lang] = nil
+        changed()
+      else
+        set(lang, PHASES[text:match("^%a+")] or "installing", text)
+      end
+    end
+    return info(self, message, ...)
+  end
+
+  local err = logger.error
+  logger.error = function(self, message, ...)
+    local text = err(self, message, ...)
+    local lang = lang_of(self.ctx)
+    if lang then
+      set(lang, "failed", text)
+    end
+    return text
+  end
+
+  hooked = true
+  return true
+end
+
+---@return table<string, TSTrackEntry>
+function M.state()
+  return state
+end
+
+---@return boolean
+function M.busy()
+  for _, entry in pairs(state) do
+    if entry.phase ~= "failed" then
+      return true
+    end
+  end
+  return false
+end
+
+---Drop tracking for languages that reached a healthy state on disk, so a
+---failure from an earlier run stops being reported once it is fixed.
+---@param healthy table<string, boolean>
+function M.settle(healthy)
+  local dropped = false
+  for lang, entry in pairs(state) do
+    if healthy[lang] and entry.phase == "failed" then
+      state[lang] = nil
+      dropped = true
+    end
+  end
+  if dropped then
+    changed()
+  end
+end
+
+---@param fn function
+---@return integer id
+function M.subscribe(fn)
+  local id = next_subscriber
+  next_subscriber = id + 1
+  subscribers[id] = fn
+  return id
+end
+
+---@param id integer
+function M.unsubscribe(id)
+  subscribers[id] = nil
+end
+
+return M

--- a/lua/tsstatus/ui.lua
+++ b/lua/tsstatus/ui.lua
@@ -6,6 +6,7 @@
 -- healthy parsers would bury the two that failed.
 
 local data = require("tsstatus.data")
+local track = require("tsstatus.track")
 
 local M = {}
 
@@ -20,6 +21,8 @@ local NS = vim.api.nvim_create_namespace("tsstatus")
 
 ---@type TSStatusSection[]
 local SECTIONS = {
+  { state = "installing", label = "installing", icon = "•", hl = "DiagnosticInfo", collapsed = false },
+  { state = "failed", label = "failed", icon = "!", hl = "DiagnosticError", collapsed = false },
   { state = "missing", label = "missing", icon = "✗", hl = "DiagnosticError", collapsed = false },
   { state = "outdated", label = "outdated", icon = "⟳", hl = "DiagnosticWarn", collapsed = false },
   { state = "orphan", label = "not in registry", icon = "?", hl = "DiagnosticInfo", collapsed = true },
@@ -27,10 +30,15 @@ local SECTIONS = {
   { state = "installed", label = "up to date", icon = "✓", hl = "DiagnosticOk", collapsed = true },
 }
 
+local SPINNER = { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" }
+local TICK_MS = 120
+
 local HELP = "q close   r refresh   <Tab> fold section"
 
 ---@type table<string, boolean>?
 local collapsed = nil
+
+local frame = 1
 
 ---@param rev string?
 ---@return string
@@ -48,7 +56,11 @@ end
 ---@param entry TSStatusEntry
 ---@return string
 local function detail(entry)
-  if entry.state == "outdated" then
+  if entry.state == "installing" then
+    return entry.phase or "queued"
+  elseif entry.state == "failed" then
+    return entry.message or "install failed"
+  elseif entry.state == "outdated" then
     return ("%s -> %s"):format(short(entry.have), short(entry.wanted))
   elseif entry.state == "missing" then
     return short(entry.wanted)
@@ -58,6 +70,15 @@ local function detail(entry)
     return "installed by something else"
   end
   return short(entry.have)
+end
+
+---@param section TSStatusSection
+---@return string
+local function icon_of(section)
+  if section.state == "installing" then
+    return SPINNER[frame]
+  end
+  return section.icon
 end
 
 ---@param report TSStatusReport
@@ -91,7 +112,11 @@ local function render(report)
   local summary = {}
   for _, section in ipairs(SECTIONS) do
     local count = report.counts[section.state] or 0
-    summary[#summary + 1] = ("%s %d %s"):format(section.icon, count, section.label)
+    -- States at zero are noise, except "up to date" which is the number the
+    -- screen exists to show even when it is the only one left.
+    if count > 0 or section.state == "installed" then
+      summary[#summary + 1] = ("%s %d %s"):format(icon_of(section), count, section.label)
+    end
   end
   add(" " .. table.concat(summary, "   "), "Title")
   add("")
@@ -101,13 +126,13 @@ local function render(report)
     if #entries > 0 then
       local folded = collapsed[section.state]
       local row =
-        add((" %s %s (%d)%s"):format(section.icon, section.label, #entries, folded and "  ..." or ""), section.hl)
+        add((" %s %s (%d)%s"):format(icon_of(section), section.label, #entries, folded and "  ..." or ""), section.hl)
       section_of_line[row] = section.state
       if not folded then
         for _, entry in ipairs(entries) do
           -- Icons are multi-byte and not all the same width, so the highlight
           -- columns are measured off the built string rather than assumed.
-          local prefix = ("   %s "):format(section.icon)
+          local prefix = ("   %s "):format(icon_of(section))
           local name = ("%-28s "):format(entry.lang)
           row = add(prefix .. name .. detail(entry))
           hls[#hls + 1] = { row, 0, #prefix, section.hl }
@@ -177,6 +202,19 @@ local function fit(win, buf)
   })
 end
 
+---@return TSStatusReport
+local function collect()
+  local report = data.collect(track.state())
+  local healthy = {}
+  for _, entry in ipairs(report.entries) do
+    if entry.state == "installed" or entry.state == "queries_only" then
+      healthy[entry.lang] = true
+    end
+  end
+  track.settle(healthy)
+  return report
+end
+
 function M.open()
   -- Fold state is per-session, not per-window: reopening the screen after an
   -- install should look the way the user left it.
@@ -187,7 +225,9 @@ function M.open()
     end
   end
 
-  local ok, report = pcall(data.collect)
+  track.setup()
+
+  local ok, report = pcall(collect)
   if not ok then
     vim.notify("TSStatus: " .. tostring(report), vim.log.levels.ERROR)
     return
@@ -214,13 +254,78 @@ function M.open()
   vim.wo[win].wrap = false
   fit(win, buf)
 
+  local function alive()
+    return vim.api.nvim_win_is_valid(win) and vim.api.nvim_buf_is_valid(buf)
+  end
+
   local function redraw(fresh)
+    if not alive() then
+      return
+    end
+    report = fresh
     local cursor = vim.api.nvim_win_get_cursor(win)
-    sections = draw(buf, fresh)
+    sections = draw(buf, report)
     fit(win, buf)
     local last = vim.api.nvim_buf_line_count(buf)
     vim.api.nvim_win_set_cursor(win, { math.min(cursor[1], last), cursor[2] })
   end
+
+  -- While an install is running the screen animates; when nothing is moving the
+  -- timer stops, so an idle window costs nothing.
+  local timer = vim.uv.new_timer()
+  local ticking = false
+
+  local function stop()
+    ticking = false
+    if timer and not timer:is_closing() then
+      timer:stop()
+    end
+  end
+
+  local function tick()
+    if not alive() then
+      stop()
+      return
+    end
+    frame = frame % #SPINNER + 1
+    redraw(collect())
+    if not track.busy() then
+      stop()
+    end
+  end
+
+  local function start()
+    if ticking or not alive() then
+      return
+    end
+    ticking = true
+    timer:start(TICK_MS, TICK_MS, vim.schedule_wrap(tick))
+  end
+
+  if track.busy() then
+    start()
+  end
+
+  -- An install can begin after the window is already open (:TSInstall from
+  -- another window), so the tracker wakes the timer rather than the timer
+  -- polling for work.
+  local subscription = track.subscribe(vim.schedule_wrap(function()
+    if track.busy() then
+      start()
+    end
+  end))
+
+  vim.api.nvim_create_autocmd({ "BufWipeout", "BufDelete" }, {
+    buffer = buf,
+    once = true,
+    callback = function()
+      stop()
+      if timer and not timer:is_closing() then
+        timer:close()
+      end
+      track.unsubscribe(subscription)
+    end,
+  })
 
   local function map(lhs, fn)
     vim.keymap.set("n", lhs, fn, { buffer = buf, nowait = true, silent = true })
@@ -233,8 +338,7 @@ function M.open()
     vim.api.nvim_win_close(win, true)
   end)
   map("r", function()
-    report = data.collect()
-    redraw(report)
+    redraw(collect())
   end)
   map("<Tab>", function()
     local row = vim.api.nvim_win_get_cursor(win)[1] - 1

--- a/lua/tsstatus/ui.lua
+++ b/lua/tsstatus/ui.lua
@@ -1,0 +1,249 @@
+-- Floating window that renders a tsstatus.data report.
+--
+-- The question this screen exists to answer is "did every parser actually get
+-- installed?", so the counts line is the payload and the lists below it are the
+-- detail. Sections that need no action start collapsed: an expanded list of 320
+-- healthy parsers would bury the two that failed.
+
+local data = require("tsstatus.data")
+
+local M = {}
+
+local NS = vim.api.nvim_create_namespace("tsstatus")
+
+---@class TSStatusSection
+---@field state TSStatusState
+---@field label string
+---@field icon string
+---@field hl string
+---@field collapsed boolean starting state
+
+---@type TSStatusSection[]
+local SECTIONS = {
+  { state = "missing", label = "missing", icon = "✗", hl = "DiagnosticError", collapsed = false },
+  { state = "outdated", label = "outdated", icon = "⟳", hl = "DiagnosticWarn", collapsed = false },
+  { state = "orphan", label = "not in registry", icon = "?", hl = "DiagnosticInfo", collapsed = true },
+  { state = "queries_only", label = "queries only", icon = "○", hl = "NonText", collapsed = true },
+  { state = "installed", label = "up to date", icon = "✓", hl = "DiagnosticOk", collapsed = true },
+}
+
+local HELP = "q close   r refresh   <Tab> fold section"
+
+---@type table<string, boolean>?
+local collapsed = nil
+
+---@param rev string?
+---@return string
+local function short(rev)
+  if not rev or rev == "" then
+    return "-"
+  end
+  -- Pinned commits are full SHAs; tags (v2.0.0) and branches stay readable as is.
+  if #rev == 40 and rev:match("^%x+$") then
+    return rev:sub(1, 7)
+  end
+  return rev
+end
+
+---@param entry TSStatusEntry
+---@return string
+local function detail(entry)
+  if entry.state == "outdated" then
+    return ("%s -> %s"):format(short(entry.have), short(entry.wanted))
+  elseif entry.state == "missing" then
+    return short(entry.wanted)
+  elseif entry.state == "queries_only" then
+    return entry.queries and "queries installed" or "queries MISSING"
+  elseif entry.state == "orphan" then
+    return "installed by something else"
+  end
+  return short(entry.have)
+end
+
+---@param report TSStatusReport
+---@return string[] lines, table[] highlights, table<integer, string> section_of_line
+local function render(report)
+  local buckets = {}
+  for _, entry in ipairs(report.entries) do
+    buckets[entry.state] = buckets[entry.state] or {}
+    table.insert(buckets[entry.state], entry)
+  end
+
+  local lines = {}
+  local hls = {}
+  local section_of_line = {}
+
+  ---@param text string
+  ---@param hl string?
+  ---@param col_start integer?
+  ---@param col_end integer?
+  local function add(text, hl, col_start, col_end)
+    lines[#lines + 1] = text
+    if hl then
+      hls[#hls + 1] = { #lines - 1, col_start or 0, col_end or -1, hl }
+    end
+    return #lines - 1
+  end
+
+  add(" " .. report.install_dir, "Comment")
+  add("")
+
+  local summary = {}
+  for _, section in ipairs(SECTIONS) do
+    local count = report.counts[section.state] or 0
+    summary[#summary + 1] = ("%s %d %s"):format(section.icon, count, section.label)
+  end
+  add(" " .. table.concat(summary, "   "), "Title")
+  add("")
+
+  for _, section in ipairs(SECTIONS) do
+    local entries = buckets[section.state] or {}
+    if #entries > 0 then
+      local folded = collapsed[section.state]
+      local row =
+        add((" %s %s (%d)%s"):format(section.icon, section.label, #entries, folded and "  ..." or ""), section.hl)
+      section_of_line[row] = section.state
+      if not folded then
+        for _, entry in ipairs(entries) do
+          -- Icons are multi-byte and not all the same width, so the highlight
+          -- columns are measured off the built string rather than assumed.
+          local prefix = ("   %s "):format(section.icon)
+          local name = ("%-28s "):format(entry.lang)
+          row = add(prefix .. name .. detail(entry))
+          hls[#hls + 1] = { row, 0, #prefix, section.hl }
+          hls[#hls + 1] = { row, #prefix + #name, -1, "Comment" }
+          section_of_line[row] = section.state
+        end
+      end
+      -- The blank separator belongs to the section above it, so <Tab> still
+      -- lands on something when the cursor is one line past a folded header.
+      section_of_line[add("")] = section.state
+    end
+  end
+
+  add(" " .. HELP, "Comment")
+
+  return lines, hls, section_of_line
+end
+
+---@param buf integer
+---@param report TSStatusReport
+---@return table<integer, string>
+local function draw(buf, report)
+  local lines, hls, section_of_line = render(report)
+
+  vim.bo[buf].modifiable = true
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  vim.bo[buf].modifiable = false
+
+  vim.api.nvim_buf_clear_namespace(buf, NS, 0, -1)
+  for _, hl in ipairs(hls) do
+    local row, col_start, col_end, group = hl[1], hl[2], hl[3], hl[4]
+    local width = #lines[row + 1]
+    if col_start <= width then
+      vim.api.nvim_buf_set_extmark(buf, NS, row, math.min(col_start, width), {
+        end_col = col_end == -1 and width or math.min(col_end, width),
+        hl_group = group,
+      })
+    end
+  end
+
+  return section_of_line
+end
+
+---@param buf integer
+---@return integer width, integer height
+local function dimensions(buf)
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+  local width = 0
+  for _, line in ipairs(lines) do
+    width = math.max(width, vim.fn.strdisplaywidth(line))
+  end
+  -- Folding a section changes the content height by hundreds of lines, so the
+  -- window is sized from what was actually rendered rather than once at open.
+  return math.min(math.max(width + 1, 60), vim.o.columns - 4), math.min(#lines, vim.o.lines - 6)
+end
+
+---@param win integer
+---@param buf integer
+local function fit(win, buf)
+  local width, height = dimensions(buf)
+  vim.api.nvim_win_set_config(win, {
+    relative = "editor",
+    width = width,
+    height = height,
+    row = math.floor((vim.o.lines - height) / 2) - 1,
+    col = math.floor((vim.o.columns - width) / 2),
+  })
+end
+
+function M.open()
+  -- Fold state is per-session, not per-window: reopening the screen after an
+  -- install should look the way the user left it.
+  if not collapsed then
+    collapsed = {}
+    for _, section in ipairs(SECTIONS) do
+      collapsed[section.state] = section.collapsed
+    end
+  end
+
+  local ok, report = pcall(data.collect)
+  if not ok then
+    vim.notify("TSStatus: " .. tostring(report), vim.log.levels.ERROR)
+    return
+  end
+
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.bo[buf].bufhidden = "wipe"
+  vim.bo[buf].filetype = "tsstatus"
+
+  local sections = draw(buf, report)
+
+  local win = vim.api.nvim_open_win(buf, true, {
+    relative = "editor",
+    width = 60,
+    height = 10,
+    row = 0,
+    col = 0,
+    style = "minimal",
+    border = "rounded",
+    title = " tree-sitter parsers ",
+    title_pos = "center",
+  })
+  vim.wo[win].cursorline = true
+  vim.wo[win].wrap = false
+  fit(win, buf)
+
+  local function redraw(fresh)
+    local cursor = vim.api.nvim_win_get_cursor(win)
+    sections = draw(buf, fresh)
+    fit(win, buf)
+    local last = vim.api.nvim_buf_line_count(buf)
+    vim.api.nvim_win_set_cursor(win, { math.min(cursor[1], last), cursor[2] })
+  end
+
+  local function map(lhs, fn)
+    vim.keymap.set("n", lhs, fn, { buffer = buf, nowait = true, silent = true })
+  end
+
+  map("q", function()
+    vim.api.nvim_win_close(win, true)
+  end)
+  map("<Esc>", function()
+    vim.api.nvim_win_close(win, true)
+  end)
+  map("r", function()
+    report = data.collect()
+    redraw(report)
+  end)
+  map("<Tab>", function()
+    local row = vim.api.nvim_win_get_cursor(win)[1] - 1
+    local state = sections[row]
+    if state then
+      collapsed[state] = not collapsed[state]
+      redraw(report)
+    end
+  end)
+end
+
+return M

--- a/lua/tsstatus/ui.lua
+++ b/lua/tsstatus/ui.lua
@@ -5,6 +5,7 @@
 -- detail. Sections that need no action start collapsed: an expanded list of 320
 -- healthy parsers would bury the two that failed.
 
+local actions = require("tsstatus.actions")
 local data = require("tsstatus.data")
 local track = require("tsstatus.track")
 
@@ -21,7 +22,7 @@ local NS = vim.api.nvim_create_namespace("tsstatus")
 
 ---@type TSStatusSection[]
 local SECTIONS = {
-  { state = "installing", label = "installing", icon = "•", hl = "DiagnosticInfo", collapsed = false },
+  { state = "installing", label = "in progress", icon = "•", hl = "DiagnosticInfo", collapsed = false },
   { state = "failed", label = "failed", icon = "!", hl = "DiagnosticError", collapsed = false },
   { state = "missing", label = "missing", icon = "✗", hl = "DiagnosticError", collapsed = false },
   { state = "outdated", label = "outdated", icon = "⟳", hl = "DiagnosticWarn", collapsed = false },
@@ -33,10 +34,13 @@ local SECTIONS = {
 local SPINNER = { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" }
 local TICK_MS = 120
 
-local HELP = "q close   r refresh   <Tab> fold section"
+local HELP = "q close   r refresh   <Tab> fold   i install   u update all   x uninstall   / filter"
 
 ---@type table<string, boolean>?
 local collapsed = nil
+
+---Substring the list is narrowed to. Empty means "show everything".
+local filter = ""
 
 local frame = 1
 
@@ -53,14 +57,30 @@ local function short(rev)
   return rev
 end
 
+---Installer errors carry absolute paths and can run to several hundred
+---characters; the row only has to say which parser broke and roughly why.
+---:TSLog still has the whole thing.
+---@param text string
+---@return string
+local function truncate(text)
+  local limit = 60
+  if vim.fn.strchars(text) <= limit then
+    return text
+  end
+  return vim.fn.strcharpart(text, 0, limit - 1) .. "…"
+end
+
 ---@param entry TSStatusEntry
 ---@return string
 local function detail(entry)
   if entry.state == "installing" then
     return entry.phase or "queued"
   elseif entry.state == "failed" then
-    return entry.message or "install failed"
+    return truncate(entry.message or "install failed")
   elseif entry.state == "outdated" then
+    if entry.queries_missing then
+      return "queries missing"
+    end
     return ("%s -> %s"):format(short(entry.have), short(entry.wanted))
   elseif entry.state == "missing" then
     return short(entry.wanted)
@@ -81,18 +101,28 @@ local function icon_of(section)
   return section.icon
 end
 
+---@class TSStatusRowMap
+---@field section table<integer, TSStatusState>
+---@field entry table<integer, TSStatusEntry>
+---@field langs table<TSStatusState, string[]>
+
 ---@param report TSStatusReport
----@return string[] lines, table[] highlights, table<integer, string> section_of_line
+---@return string[] lines, table[] highlights, TSStatusRowMap map
 local function render(report)
   local buckets = {}
+  local langs = {}
   for _, entry in ipairs(report.entries) do
-    buckets[entry.state] = buckets[entry.state] or {}
-    table.insert(buckets[entry.state], entry)
+    langs[entry.state] = langs[entry.state] or {}
+    table.insert(langs[entry.state], entry.lang)
+    if filter == "" or entry.lang:find(filter, 1, true) then
+      buckets[entry.state] = buckets[entry.state] or {}
+      table.insert(buckets[entry.state], entry)
+    end
   end
 
   local lines = {}
   local hls = {}
-  local section_of_line = {}
+  local map = { section = {}, entry = {}, langs = langs }
 
   ---@param text string
   ---@param hl string?
@@ -127,7 +157,7 @@ local function render(report)
       local folded = collapsed[section.state]
       local row =
         add((" %s %s (%d)%s"):format(icon_of(section), section.label, #entries, folded and "  ..." or ""), section.hl)
-      section_of_line[row] = section.state
+      map.section[row] = section.state
       if not folded then
         for _, entry in ipairs(entries) do
           -- Icons are multi-byte and not all the same width, so the highlight
@@ -137,25 +167,29 @@ local function render(report)
           row = add(prefix .. name .. detail(entry))
           hls[#hls + 1] = { row, 0, #prefix, section.hl }
           hls[#hls + 1] = { row, #prefix + #name, -1, "Comment" }
-          section_of_line[row] = section.state
+          map.section[row] = section.state
+          map.entry[row] = entry
         end
       end
       -- The blank separator belongs to the section above it, so <Tab> still
       -- lands on something when the cursor is one line past a folded header.
-      section_of_line[add("")] = section.state
+      map.section[add("")] = section.state
     end
   end
 
+  if filter ~= "" then
+    add((" filter: %s   (/ to change, / then <CR> to clear)"):format(filter), "WarningMsg")
+  end
   add(" " .. HELP, "Comment")
 
-  return lines, hls, section_of_line
+  return lines, hls, map
 end
 
 ---@param buf integer
 ---@param report TSStatusReport
----@return table<integer, string>
+---@return TSStatusRowMap
 local function draw(buf, report)
-  local lines, hls, section_of_line = render(report)
+  local lines, hls, map = render(report)
 
   vim.bo[buf].modifiable = true
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
@@ -173,7 +207,7 @@ local function draw(buf, report)
     end
   end
 
-  return section_of_line
+  return map
 end
 
 ---@param buf integer
@@ -204,15 +238,10 @@ end
 
 ---@return TSStatusReport
 local function collect()
-  local report = data.collect(track.state())
-  local healthy = {}
-  for _, entry in ipairs(report.entries) do
-    if entry.state == "installed" or entry.state == "queries_only" then
-      healthy[entry.lang] = true
-    end
-  end
-  track.settle(healthy)
-  return report
+  -- A failure is deliberately sticky: it clears when the installer is asked to
+  -- try that language again, not when the parser file happens to look fine.
+  -- An install can leave the parser in place and still have failed.
+  return data.collect(track.state())
 end
 
 function M.open()
@@ -237,7 +266,7 @@ function M.open()
   vim.bo[buf].bufhidden = "wipe"
   vim.bo[buf].filetype = "tsstatus"
 
-  local sections = draw(buf, report)
+  local rows = draw(buf, report)
 
   local win = vim.api.nvim_open_win(buf, true, {
     relative = "editor",
@@ -264,7 +293,7 @@ function M.open()
     end
     report = fresh
     local cursor = vim.api.nvim_win_get_cursor(win)
-    sections = draw(buf, report)
+    rows = draw(buf, report)
     fit(win, buf)
     local last = vim.api.nvim_buf_line_count(buf)
     vim.api.nvim_win_set_cursor(win, { math.min(cursor[1], last), cursor[2] })
@@ -310,8 +339,15 @@ function M.open()
   -- another window), so the tracker wakes the timer rather than the timer
   -- polling for work.
   local subscription = track.subscribe(vim.schedule_wrap(function()
+    if not alive() then
+      return
+    end
     if track.busy() then
       start()
+    else
+      -- A short install can begin and end between two ticks, so the last event
+      -- has to redraw by itself or the screen keeps showing the old state.
+      redraw(collect())
     end
   end))
 
@@ -331,6 +367,63 @@ function M.open()
     vim.keymap.set("n", lhs, fn, { buffer = buf, nowait = true, silent = true })
   end
 
+  ---@return TSStatusState? state, TSStatusEntry? entry
+  local function under_cursor()
+    local row = vim.api.nvim_win_get_cursor(win)[1] - 1
+    return rows.section[row], rows.entry[row]
+  end
+
+  ---Languages the cursor points at: one row, or every visible row of the
+  ---section whose header (or trailing blank line) the cursor sits on.
+  ---@return string[] langs, TSStatusState? state
+  local function targets()
+    local state, entry = under_cursor()
+    if entry then
+      return { entry.lang }, state
+    end
+    if not state then
+      return {}, nil
+    end
+    local langs = {}
+    for _, candidate in ipairs(report.entries) do
+      if candidate.state == state and (filter == "" or candidate.lang:find(filter, 1, true)) then
+        langs[#langs + 1] = candidate.lang
+      end
+    end
+    return langs, state
+  end
+
+  ---Outdated parsers, split by whether nvim-treesitter can update them.
+  ---@return string[] updatable, string[] reinstall
+  local function outdated()
+    local updatable, reinstall = {}, {}
+    for _, entry in ipairs(report.entries) do
+      if entry.state == "outdated" then
+        -- update() reads <lang>.revision through an assert()ing helper
+        -- (nvim-treesitter/util.lua:6), so a parser whose revision file is
+        -- missing crashes the whole batch. Those go through a forced install
+        -- instead, which rewrites the revision file and heals the state.
+        if entry.have and entry.have ~= "" and not entry.queries_missing then
+          updatable[#updatable + 1] = entry.lang
+        else
+          reinstall[#reinstall + 1] = entry.lang
+        end
+      end
+    end
+    return updatable, reinstall
+  end
+
+  ---A whole section at once is a big, slow action, so it asks before starting.
+  ---@param verb string
+  ---@param langs string[]
+  ---@return boolean
+  local function confirmed(verb, langs)
+    if #langs <= 1 then
+      return true
+    end
+    return vim.fn.confirm(("%s %d parsers?"):format(verb, #langs), "&Yes\n&No", 2) == 1
+  end
+
   map("q", function()
     vim.api.nvim_win_close(win, true)
   end)
@@ -341,12 +434,61 @@ function M.open()
     redraw(collect())
   end)
   map("<Tab>", function()
-    local row = vim.api.nvim_win_get_cursor(win)[1] - 1
-    local state = sections[row]
+    local state = under_cursor()
     if state then
       collapsed[state] = not collapsed[state]
       redraw(report)
     end
+  end)
+
+  map("i", function()
+    local langs, state = targets()
+    if #langs == 0 then
+      return
+    end
+    -- Anything already on disk has to be forced, otherwise install() sees the
+    -- parser present and returns without doing anything.
+    local present = state ~= "missing" and state ~= "failed"
+    if not confirmed(present and "Reinstall" or "Install", langs) then
+      return
+    end
+    actions.install(langs, present)
+  end)
+
+  map("u", function()
+    -- Update is deliberately not cursor-driven: "bring everything current" is
+    -- the only version of it anyone wants, and outdated is where it applies.
+    local updatable, reinstall = outdated()
+    local total = #updatable + #reinstall
+    if total == 0 then
+      vim.notify("TSStatus: every parser is up to date", vim.log.levels.INFO)
+      return
+    end
+    local subject = {}
+    vim.list_extend(subject, updatable)
+    vim.list_extend(subject, reinstall)
+    if not confirmed("Update", subject) then
+      return
+    end
+    actions.update(updatable)
+    actions.install(reinstall, true)
+  end)
+
+  map("x", function()
+    local langs = targets()
+    if #langs > 0 then
+      actions.uninstall(langs)
+    end
+  end)
+
+  map("/", function()
+    vim.ui.input({ prompt = "Filter parsers: ", default = filter }, function(input)
+      if input == nil then
+        return
+      end
+      filter = vim.trim(input)
+      redraw(report)
+    end)
   end)
 end
 


### PR DESCRIPTION
## 問題

nvim-treesitter の parser インストールは非同期で走り、結果はログにしか出ない。`install()` はバッチ全体で 1 つの task を返すだけなので、セッションの途中で「全部入ったのか」「どれが失敗したのか」を確認する手段が無い。`:TSLog` は流れた順のメッセージであって、状態の一覧ではない。

## 解決

`:TSStatus` を追加する。parser の状態を 1 画面で出す。

```
 ⠙ 2 in progress   ! 1 failed   ✗ 314 missing   ○ 3 queries only   ✓ 320 up to date

 ⠙ in progress (2)
   ⠙ c                            downloading
   ⠙ rust                         compiling

 ! failed (1)
   ! json                         EEXIST: file already exists: …

 q close   r refresh   <Tab> fold   i install   u update all   x uninstall   / filter
```

- **状態**: up to date / outdated / missing / failed / queries only / レジストリ外、を revision ファイルとレジストリの突き合わせで判定する
- **進捗**: インストーラのロガーは言語ごとの context (`log.new("install/" .. lang)`) と段階メッセージを持つので、そこから download / compile / failed を復元して行に反映する。動いている間だけタイマーが回り、止まれば止まる
- **操作**: `i` インストール（行、またはセクション全体）、`u` outdated を一括更新、`x` アンインストール（確認あり）、`/` 絞り込み

## 構成

`lua/tsstatus/` は他のどのファイルにも依存しない。使うのは nvim-treesitter の公開 API（`get_available` / `get_installed` / parsers テーブル）と、インストーラが書く `<lang>.revision` だけ。将来、独立したプラグインへ切り出せる形にしてある。

- `data.lua` — ファイルシステムから状態を作る純粋な計算
- `track.lua` — ロガーを包んで進行中の状態を復元する（ここだけがプラグイン内部に触れる。無効でも `data.lua` の画面は成立する）
- `actions.lua` / `ui.lua` — 操作と描画

`lua/plugins/nvim-treesitter/init.lua` には 1 行だけ追加した。起動時のインストールを取りこぼさないよう、`install()` より前にフックを張るため。インストール処理自体は変更していない。

## 検証

実物の parser ディレクトリ（320 個）と、意図的に壊した検証用ディレクトリの両方に対して、実際の Neovim で確認した。

- `i` / `x` / `u` が本当にダウンロード・コンパイル・削除まで通り、画面が自力で更新されること
- 実際に失敗を起こし、赤い行が出て、リフレッシュしても消えないこと
- 何も動いていない間は再描画が止まること

## 実装中に見つかった注意点

- `update()` は `<lang>.revision` を assert 付きヘルパで読むため（`nvim-treesitter/util.lua:6`）、そのファイルが無い parser が 1 つでもあるとバッチ全体が落ちる。`u` は該当するものを force install に振り分けて回避する
- parser のビルドが成功して queries の設置だけ失敗する経路がある。ファイル上は健全に見えるので、失敗表示は「同じ言語を入れ直したときだけ消える」ようにした
- queries が無い parser は revision が一致していても壊れている（ハイライトが動かない）ので outdated として扱う


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Tree-sitter status interface available through `:TSStatus`.
  * View parser states including installing, installed, outdated, failed, missing, and orphaned.
  * Added filtering, folding, refresh controls, progress updates, and parser install, update, and uninstall actions.
  * Uninstall operations now require confirmation.
  * Status information updates live during parser activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->