### PR TITLE
fix(keymaps): drop rhs-less leader group stubs (§5-1)

### DIFF
--- a/lua/plugins/brewfile-nvim/keys.lua
+++ b/lua/plugins/brewfile-nvim/keys.lua
@@ -1,14 +1,6 @@
 ---@type LazyKeysSpec[]
 local keys = {
   {
-    "<leader>B",
-    mode = {
-      "n",
-    },
-    desc = "Brewfile",
-    silent = true,
-  },
-  {
     "<leader>Bi",
     function()
       require("brewfile").install()

--- a/lua/plugins/claudecode-nvim/keys.lua
+++ b/lua/plugins/claudecode-nvim/keys.lua
@@ -1,12 +1,6 @@
 ---@type LazyKeysSpec[]
 local keys = {
   {
-    "<leader>a",
-    nil,
-    desc = "AI/Claude Code",
-    silent = true,
-  },
-  {
     "<leader>ac",
     "<cmd>ClaudeCode<cr>",
     desc = "Toggle Claude",

--- a/lua/plugins/snacks-nvim/keys.lua
+++ b/lua/plugins/snacks-nvim/keys.lua
@@ -57,14 +57,6 @@ local keys = {
     silent = true,
   },
   {
-    "<leader>u",
-    mode = {
-      "n",
-    },
-    desc = "UI toggles",
-    silent = true,
-  },
-  {
     "<leader>bc",
     function()
       require("snacks").bufdelete()


### PR DESCRIPTION
Implements §5-1 of `docs/plans/leader-keymap-redesign.md`.

Three `keys` entries carried a group label but no rhs. lazy.nvim still registers them, so the bare prefix waited out `timeoutlen` and then did nothing. Labels are already in which-key's spec; child keys pull the lazy load.

Measured headless on this branch, before vs after:

| | before | after |
|---|---|---|
| `<leader>a` | "AI/Claude Code" stub | aerial toggle (real mapping) |
| `<leader>B` | "Brewfile" stub | unmapped |
| `<leader>u` | not registered | not registered |
| children under a/u/B | 27 | 27 |

`<leader>u` had nothing to remove at runtime: snacks loads eagerly, so lazy never left a pending mapping. The design doc counted 3 stubs from the spec files; only 2 were live.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed unused standalone keyboard shortcuts for Brewfile, AI/Claude Code, and UI toggle menus.
  * Existing shortcuts for related commands remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->