### PR TITLE
feat(alpha): open neovim-tips from the dashboard

### DIFF
--- a/lua/plugins/alpha-nvim/opts.lua
+++ b/lua/plugins/alpha-nvim/opts.lua
@@ -17,6 +17,8 @@ theta.buttons.val = {
   { type = "padding", val = 1 },
   button("z", "󰝒  Open Telekasten Panel", "<cmd>Telekasten<CR>"),
   { type = "padding", val = 1 },
+  button("T", "󰌵  Open Tips", "<cmd>NeovimTips<CR>"),
+  { type = "padding", val = 1 },
   button("q", "󰅚  Quit", "<cmd>qa<CR>"),
 }
 

--- a/neovim_tips/user_tips.md
+++ b/neovim_tips/user_tips.md
@@ -1,2 +1,24 @@
 # Your personal Neovim tips
 
+# Title: カレントディレクトリからファイルを開く
+# Category: this_config
+# Tags: file, oil, cmdline, project
+---
+`:e <Tab>` の補完は cwd 起点。project.nvim が cwd をプロジェクトルート（`.git` などのパターン一致）へ移すので、深い階層のファイルを開いていても補完はルートから始まる。
+
+ルート起点の cwd は grep・picker・LSP root が使うので、そのままにして開き方を変える。
+
+- `-` — oil.nvim。**開いているファイルのディレクトリ**が開く。cwd は関係ない。ディレクトリを選べばそのまま下へ潜れる。既定はこれ
+- `:e %:h/<Tab>` — cmdline から。`%` が現在のファイル、`:h` がその親ディレクトリ
+- `<leader>Ff` — picker でファイル名から探す（ルート全体が対象）
+- `<leader>Fg` — picker で中身から grep
+***
+
+# Title: プラグインが張ったキーマップを引く
+# Category: this_config
+# Tags: keymap, which-key, lazy
+---
+`:PluginKeys [plugin]` — プラグイン名から、そのプラグインが張ったキーと説明を出す。which-key の逆引き。
+
+未ロードのプラグインも lazy の spec 側から拾うので、まだ動かしていないプラグインのキーも見える。
+***


### PR DESCRIPTION
## 何を

- alpha のダッシュボードに `T  Open Tips` を追加し、`:NeovimTips` の検索 picker を開く
- この設定固有の tips を neovim-tips の user tips に2件追加

## なぜ

`:e <Tab>` の補完が cwd 起点で、project.nvim が cwd をプロジェクトルートへ移すため、深い階層のファイルを開いていても補完がルートから始まる。ルート起点の cwd は grep・picker・LSP root が使うので設定は変えず、「バッファ相対で開く手段」を思い出せるようにする側で解決した。

tips の置き場は専用の `TIPS.md` ではなく neovim-tips の user tips file。見る場所が1つで済み、`daily_tip` のローテーションにも乗る。

## 動作確認（neowright）

- alpha で `T` → picker が開く（`filetype=neovim-tips-search`、insert モードで即入力）
- `t:user` で絞ると追加した2件が出て、右パネルに本文が描画される
- `user_tips=2` / `total=2400`（内蔵 2398 件と共存、タイトル衝突警告なし）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dashboard button for opening Neovim tips.
  * Added guidance on opening files from different directories.
  * Added guidance for inspecting plugin-defined keymaps with `:PluginKeys`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->