### PR TITLE
feat(cokeline): nth-buffer / pick / reorder mappings and a tabline-ordered picker

### DIFF
--- a/lua/plugins/nvim-cokeline/keys.lua
+++ b/lua/plugins/nvim-cokeline/keys.lua
@@ -1,3 +1,8 @@
+-- NOTE: `scripts/check-keys-spec.lua` lints this file with a bare `dofile()`, outside the Neovim
+-- runtime, so nothing here may `require()` cokeline or the sibling picker module at file scope.
+-- Every such call stays inside an rhs function, which only ever runs after lazy.nvim has loaded
+-- the plugin.
+
 ---@type LazyKeysSpec[]
 local keys = {
   {
@@ -16,6 +21,156 @@ local keys = {
       "n",
     },
     desc = "Cokeline: focus prev buffer",
+    silent = true,
+  },
+  {
+    "<leader>b1",
+    "<Plug>(cokeline-focus-1)",
+    mode = {
+      "n",
+    },
+    desc = "Cokeline: focus buffer 1",
+    silent = true,
+  },
+  {
+    "<leader>b2",
+    "<Plug>(cokeline-focus-2)",
+    mode = {
+      "n",
+    },
+    desc = "Cokeline: focus buffer 2",
+    silent = true,
+  },
+  {
+    "<leader>b3",
+    "<Plug>(cokeline-focus-3)",
+    mode = {
+      "n",
+    },
+    desc = "Cokeline: focus buffer 3",
+    silent = true,
+  },
+  {
+    "<leader>b4",
+    "<Plug>(cokeline-focus-4)",
+    mode = {
+      "n",
+    },
+    desc = "Cokeline: focus buffer 4",
+    silent = true,
+  },
+  {
+    "<leader>b5",
+    "<Plug>(cokeline-focus-5)",
+    mode = {
+      "n",
+    },
+    desc = "Cokeline: focus buffer 5",
+    silent = true,
+  },
+  {
+    "<leader>b6",
+    "<Plug>(cokeline-focus-6)",
+    mode = {
+      "n",
+    },
+    desc = "Cokeline: focus buffer 6",
+    silent = true,
+  },
+  {
+    "<leader>b7",
+    "<Plug>(cokeline-focus-7)",
+    mode = {
+      "n",
+    },
+    desc = "Cokeline: focus buffer 7",
+    silent = true,
+  },
+  {
+    "<leader>b8",
+    "<Plug>(cokeline-focus-8)",
+    mode = {
+      "n",
+    },
+    desc = "Cokeline: focus buffer 8",
+    silent = true,
+  },
+  {
+    "<leader>b9",
+    "<Plug>(cokeline-focus-9)",
+    mode = {
+      "n",
+    },
+    desc = "Cokeline: focus buffer 9",
+    silent = true,
+  },
+  {
+    "<leader>b$",
+    -- `<Plug>(cokeline-focus-N)` only exists for a fixed 1..20, so "last" has to be computed.
+    function()
+      local state = require("cokeline.state")
+      require("cokeline.mappings").by_index("focus", #state.visible_buffers)
+    end,
+    mode = {
+      "n",
+    },
+    desc = "Cokeline: focus last buffer",
+    silent = true,
+  },
+  {
+    "<leader>bP",
+    "<Plug>(cokeline-pick-focus)",
+    mode = {
+      "n",
+    },
+    desc = "Cokeline: pick buffer to focus",
+    silent = true,
+  },
+  {
+    "<leader>bd",
+    "<Plug>(cokeline-pick-close)",
+    mode = {
+      "n",
+    },
+    desc = "Cokeline: pick buffer to close",
+    silent = true,
+  },
+  {
+    "<leader>bD",
+    "<Plug>(cokeline-pick-close-multiple)",
+    mode = {
+      "n",
+    },
+    desc = "Cokeline: pick buffers to close (repeating)",
+    silent = true,
+  },
+  {
+    "<leader>bH",
+    "<Plug>(cokeline-switch-prev)",
+    mode = {
+      "n",
+    },
+    desc = "Cokeline: move buffer left",
+    silent = true,
+  },
+  {
+    "<leader>bL",
+    "<Plug>(cokeline-switch-next)",
+    mode = {
+      "n",
+    },
+    desc = "Cokeline: move buffer right",
+    silent = true,
+  },
+  {
+    "<leader>bf",
+    function()
+      require("plugins.nvim-cokeline.picker").buffers()
+    end,
+    mode = {
+      "n",
+    },
+    desc = "Cokeline: pick buffer (fuzzy, tabline order)",
     silent = true,
   },
 }

--- a/lua/plugins/nvim-cokeline/opts/init.lua
+++ b/lua/plugins/nvim-cokeline/opts/init.lua
@@ -1,6 +1,98 @@
--- Intentionally empty: run on cokeline's defaults first, tune later.
+-- cokeline's `components` is a *list*, and `cokeline/config.lua`'s `update()` replaces lists
+-- wholesale instead of merging them. So the moment one extra component is wanted, the whole
+-- default list has to be spelled out here.
+--
+-- Everything after the first entry is a verbatim copy of `defaults.components` in
+-- CODES/lua/cokeline/config.lua; keep it in sync when the plugin is updated.
+--
+-- The added first entry is what makes two mapping families usable at all:
+--   - `<leader>b1`..`<leader>b9` -> `<Plug>(cokeline-focus-N)` needs the index on screen
+--   - `<leader>bP` / `<leader>bd` -> `mappings.pick(...)` blocks on `getchar()` waiting for a
+--     `pick_letter` that the default components never render
+--
+-- Colours go through `hlgroups.get_hl_attr` rather than literal hex so they follow the
+-- colorscheme, the same way the stock `unique_prefix` component does.
 -- See CODES/lua/cokeline/config.lua for every available option.
+
+local function is_picking()
+  local mappings = require("cokeline.mappings")
+  return mappings.is_picking_focus() or mappings.is_picking_close()
+end
+
 ---@type table
-local opts = {}
+local opts = {
+  components = {
+    -- Normally the buffer index; switches to the pick letter while a pick is in flight.
+    {
+      text = function(buffer)
+        if is_picking() then
+          return " " .. buffer.pick_letter
+        end
+        return " " .. buffer.index
+      end,
+      fg = function()
+        local mappings = require("cokeline.mappings")
+        local hlgroups = require("cokeline.hlgroups")
+        if mappings.is_picking_focus() then
+          return hlgroups.get_hl_attr("Question", "fg")
+        elseif mappings.is_picking_close() then
+          return hlgroups.get_hl_attr("WarningMsg", "fg")
+        end
+        return hlgroups.get_hl_attr("Comment", "fg")
+      end,
+      bold = function()
+        return is_picking()
+      end,
+    },
+    {
+      text = function(buffer)
+        return " " .. buffer.devicon.icon
+      end,
+      fg = function(buffer)
+        return buffer.devicon.color
+      end,
+    },
+    {
+      text = function(buffer)
+        return buffer.unique_prefix
+      end,
+      fg = function()
+        return require("cokeline.hlgroups").get_hl_attr("Comment", "fg")
+      end,
+      italic = true,
+    },
+    {
+      text = function(buffer)
+        return buffer.filename
+      end,
+      underline = function(buffer)
+        if buffer.is_hovered and not buffer.is_focused then
+          return true
+        end
+      end,
+    },
+    {
+      text = " ",
+    },
+    {
+      ---@param buffer Buffer
+      text = function(buffer)
+        if buffer.is_modified then
+          return ""
+        end
+        if buffer.is_hovered then
+          return "󰅙"
+        end
+        return "󰅖"
+      end,
+      on_click = function(_, _, _, _, buffer)
+        buffer:delete()
+      end,
+    },
+    {
+      text = " ",
+    },
+  },
+}
 
 return opts

--- a/lua/plugins/nvim-cokeline/picker.lua
+++ b/lua/plugins/nvim-cokeline/picker.lua
@@ -1,0 +1,83 @@
+-- Fuzzy buffer picker that honours cokeline's own buffer order.
+--
+-- `<leader>Fb` (lua/config/picker.lua) already offers a backend-agnostic buffer picker, but it
+-- lists buffers in bufnr order. Once `<leader>bH` / `<leader>bL` have moved buffers around, the
+-- tabline order and the bufnr order disagree, and the picker no longer matches what is on screen.
+-- This module reads `cokeline.state.visible_buffers` so the picker lists exactly the tabline,
+-- in exactly the tabline's order.
+--
+-- snacks-only, deliberately: cokeline order needs a custom finder, and a telescope equivalent
+-- would mean a separate `finders.new_table` + `entry_maker`. It is therefore NOT registered as a
+-- source in `lua/config/picker.lua`, and `<leader>uf` does not affect it. When bufnr order is
+-- good enough, `<leader>Fb` remains available on both backends.
+
+local M = {}
+
+---Open a snacks picker over cokeline's visible buffers, in tabline order.
+function M.buffers()
+  -- snacks is lazy-loaded, so it may not be on the runtimepath yet when the keymap fires.
+  pcall(function()
+    require("lazy").load({
+      plugins = {
+        "snacks.nvim",
+      },
+    })
+  end)
+
+  local state = require("cokeline.state")
+  local visible = state.visible_buffers
+
+  -- `visible_buffers` is populated while the tabline renders, so it is empty until the first draw.
+  if not visible or #visible == 0 then
+    vim.notify("cokeline: no visible buffers to pick from", vim.log.levels.WARN)
+    return
+  end
+
+  -- Snapshot the buffers now: the picker's finder runs later, and cokeline rebuilds the list on
+  -- every redraw.
+  local items = {}
+  for _, buffer in ipairs(visible) do
+    local path = buffer.path
+    items[#items + 1] = {
+      -- The default sort is score desc, then `idx`, so with an empty query the tabline order wins.
+      idx = buffer.index,
+      buf = buffer.number,
+      file = path ~= "" and path or buffer.filename,
+      -- What the matcher scans; the index is included so "3" narrows to the third buffer.
+      text = ("%d %s"):format(buffer.index, path ~= "" and path or buffer.filename),
+    }
+  end
+
+  -- `format = "buffer"` reuses snacks' own buffer rendering and preview, which only read
+  -- `item.buf`. The `<c-x>` / `dd` delete keys do NOT come with it: they live in the `buffers`
+  -- entry of snacks' `picker/config/sources.lua`, and a custom `source` name gets no source
+  -- config at all. They are restored here so this picker behaves like `<leader>Fb`.
+  require("snacks").picker.pick({
+    source = "cokeline_buffers",
+    title = "Cokeline Buffers",
+    format = "buffer",
+    finder = function()
+      return items
+    end,
+    win = {
+      input = {
+        keys = {
+          ["<c-x>"] = {
+            "bufdelete",
+            mode = {
+              "n",
+              "i",
+            },
+          },
+        },
+      },
+      list = {
+        keys = {
+          ["dd"] = "bufdelete",
+        },
+      },
+    },
+  })
+end
+
+return M


### PR DESCRIPTION
## 問題

`nvim-cokeline` のマッピングが `<leader>bn` / `<leader>bp` の2つしかなく、プラグインが持つ機能のほとんどに手が届いていなかった。

調べたところ、単にキーを足すだけでは足りないことが分かった。

- `opts/init.lua` が空＝デフォルト component のままで、**index 番号も `pick_letter` も描画されない**。`<Plug>(cokeline-focus-3)` は「どれが3番か」が見えず、`mappings.pick()` は画面に出ていないレターを `getchar()` で待ち続ける。
- バッファ picker は `<leader>Fb` が既にあるが bufnr 順で、`switch` でタブラインを並べ替えると表示と食い違う。

## 解決

3コミットに分けた。

1. **`opts/init.lua`** — 通常は index、pick 中は `pick_letter` に切り替わる先頭 component を追加。`components` はリストで cokeline の `update()` が丸ごと差し替えるため、デフォルト一式を書き下ろしている。色は `hlgroups.get_hl_attr` 経由で colorscheme に追従。
2. **`picker.lua`（新規）** — `cokeline.state.visible_buffers` の順で items を組む snacks picker。`<leader>Fb` は bufnr 順のまま残す。snacks 専用で、`lua/config/picker.lua` のルータには載せていない（理由はファイル冒頭のコメント）。
3. **`keys.lua`** — `<leader>b` 配下に追加:

| lhs | 動作 |
|---|---|
| `<leader>b1`〜`b9` / `b$` | n番目 / 最後のバッファへフォーカス |
| `<leader>bP` | レターでバッファを選んでフォーカス |
| `<leader>bd` / `bD` | レターでバッファを選んで閉じる（`bD` は連続） |
| `<leader>bH` / `bL` | カレントバッファをタブライン上で左右へ移動 |
| `<leader>bf` | タブライン順の fuzzy picker |

## 検証

`task ck` / `stylua --check` / `selene` はいずれもクリーン（`task ck` の既存 FAIL は `noice-nvim` と `nvim-dora` で本 PR とは無関係）。

UI が絡むので headless ではなく実 nvim（neowright、`NVIM_APPNAME` 分離の worktree）で確認した:

- タブラインに index 番号が出る
- `<leader>b3` → 3番目、`<leader>b$` → 最後にフォーカス
- `<leader>bH` でバッファが 5→4 番目へ移動
- `<leader>bP` で番号がレター表示に切り替わり、打鍵で該当バッファへ
- `<leader>bd` で1つ、`<leader>bD` で2つ連続して閉じられる
- `<leader>bf` の並びがタブラインと一致（bufnr 順ではない）、選択と `<c-x>` 削除が動く
- `<leader>Fb` は従来どおり

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added buffer navigation shortcuts for focusing buffers 1–9 or the last visible buffer.
  - Added commands to select, close, and move buffers left or right.
  - Added a fuzzy buffer picker with support for selecting and deleting buffers.
  - Enhanced the buffer line with indices, pick letters, file icons, filenames, modified indicators, and close controls.
  - Added visual highlighting for focused, hovered, and actionable buffer states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->